### PR TITLE
Remove the option to configure the JSON provider.

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/NakadiClient.java
+++ b/nakadi-java-client/src/main/java/nakadi/NakadiClient.java
@@ -193,15 +193,6 @@ public class NakadiClient {
     }
 
     /**
-     * Optionally set the JSON support class.
-     */
-    @Deprecated
-    public Builder jsonSupport(JsonSupport jsonSupport) {
-      this.jsonSupport = jsonSupport;
-      return this;
-    }
-
-    /**
      * Optionally set the token provider. Not setting a provider will mean no bearer tokens are
      * sent to the server by default.
      */


### PR DESCRIPTION
Internally, except for one scenario, API handling is abstracted
away from Gson and could use any provider. There's arguably little
value in allowing pluggable JSON support for a client that's
focused on production/ops behaviour - it just provides a vector for
errors. For example, supplying a JSON option that is not configured
to skip nulls won't work with the server API in certain cases. As
another example cursor JSON in headers should be whitespace
compressed. The internal JSON provider abstraction is kept as that's
useful for organizing the code.