### PR TITLE
Make UndefinedEventMapped and BusinessEventMapped generic.

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/BusinessEventMapped.java
+++ b/nakadi-java-client/src/main/java/nakadi/BusinessEventMapped.java
@@ -12,30 +12,38 @@ import java.util.Objects;
  * like a raw string.
  * <p></p>
  * {@link BusinessEventMapped} works around this by marshalling custom fields found on the top level
- * JSON event into the {@link BusinessEventMapped#data} Map. As such it doesn't exactly represent
+ * JSON event into the {@link BusinessEventMapped#data} field. As such it doesn't exactly represent
  * the data on the wire.
  */
-public class BusinessEventMapped implements Event {
+public class BusinessEventMapped<T> implements Event {
 
-  private Map<String, Object> data;
+  private T data;
   private EventMetadata metadata;
+
+  public BusinessEventMapped() {
+  }
+
+  public BusinessEventMapped(T data, EventMetadata metadata) {
+    this.data = data;
+    this.metadata = metadata;
+  }
 
   /**
    * The mapped data
    */
-  public BusinessEventMapped data(Map<String, Object> data) {
+  public BusinessEventMapped<T> data(T data) {
     this.data = data;
     return this;
   }
 
-  public Map<String, Object> data() {
+  public T data() {
     return data;
   }
 
   /**
    * The event metadata
    */
-  public BusinessEventMapped metadata(EventMetadata metadata) {
+  public BusinessEventMapped<T> metadata(EventMetadata metadata) {
     this.metadata = metadata;
     return this;
   }

--- a/nakadi-java-client/src/main/java/nakadi/EventMappedSupport.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventMappedSupport.java
@@ -3,6 +3,7 @@ package nakadi;
 import com.google.common.collect.Maps;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Map;
 
@@ -14,21 +15,23 @@ class EventMappedSupport {
 
   private static final String METADATA_FIELD = "metadata";
   private static final GsonSupport gson = new GsonSupport();
-  private static TypeLiteral<BusinessEventMapped> businessEventMappedTypeLiteral =
-      new TypeLiteral<BusinessEventMapped>() {
-      };
-  private static TypeLiteral<UndefinedEventMapped> undefinedEventMappedTypeLiteral =
-      new TypeLiteral<UndefinedEventMapped>() {
-      };
 
   static Object mapEventRecordToSerdes(EventRecord<? extends Event> eventRecord) {
 
     if (eventRecord.event().getClass().isAssignableFrom(BusinessEventMapped.class)) {
-      BusinessEventMapped mapped = (BusinessEventMapped) eventRecord.event();
-      Map<String, Object> data = Maps.newHashMap();
-      data.put("metadata", mapped.metadata());
-      data.putAll(mapped.data());
-      return data;
+
+      BusinessEventMapped businessEvent = (BusinessEventMapped) eventRecord.event();
+      Map<String, Object> jsonEvent = Maps.newHashMap();
+      jsonEvent.put("metadata", businessEvent.metadata());
+      /*
+      :hack: take the businessEvent.data field whose type we don't know and roundtrip it to
+      a JSON string and back into to a regular map, so we can place that resulting map's fields
+      into the top level of the jsonEvent. The result is an event that gets published to
+      Nakadi whose fields are all in the top level JSON doc as per the the business category
+      definition.
+       */
+      jsonEvent.putAll(gson.fromJson(gson.toJson(businessEvent.data()), MAP_TYPE));
+      return jsonEvent;
     }
 
     if (eventRecord.event().getClass().isAssignableFrom(UndefinedEventMapped.class)) {
@@ -46,20 +49,63 @@ class EventMappedSupport {
     return rawType.isAssignableFrom(c);
   }
 
-  static UndefinedEventMapped marshalUndefinedEventMapped(Map<String, Object> data) {
-    return new UndefinedEventMapped().data(data);
+  static <T> UndefinedEventMapped<T> marshalUndefinedEventMapped(String raw, Type type,
+      JsonSupport jsonSupport) {
+
+    if (!EventMappedSupport.isAssignableFrom(type, UndefinedEventMapped.class)) {
+      throw new IllegalArgumentException(
+          "Supplied type must be assignable from UndefinedEventMapped " + type.getTypeName());
+    }
+
+    if (type instanceof ParameterizedType) {
+      /*
+      we want the generic parameter type of T captured by UndefinedEventMapped<T> as that's
+      what'll we deser the json with before setting it into UndefinedEventMapped.data. This is
+      expected to work as well for a T that is itself carrying a generic or a generic collection.
+      See EventMappedSupportTest.
+      */
+      ParameterizedType genericType = (ParameterizedType) type;
+      Type[] actualTypeArguments = genericType.getActualTypeArguments();
+      Type serdeType = actualTypeArguments[0];
+      T data = jsonSupport.fromJson(raw, serdeType);
+      return new UndefinedEventMapped<>(data);
+    } else {
+      throw new IllegalArgumentException(
+          "Supplied type must be a parameterized UndefinedEventMapped"
+              + type.getTypeName());
+    }
   }
 
-  static BusinessEventMapped marshalBusinessEventMapped(String raw, JsonSupport jsonSupport) {
+  static <T> BusinessEventMapped<T> marshalBusinessEventMapped(String raw, Type type, JsonSupport jsonSupport) {
+
+    if (!EventMappedSupport.isAssignableFrom(type, BusinessEventMapped.class)) {
+      throw new IllegalArgumentException(
+          "Supplied type must be assignable BusinessEventMapped " + type.getTypeName());
+    }
+
     JsonObject jo = jsonSupport.fromJson(raw, JsonObject.class);
 
     // pluck out the metadata block and marshal it
     EventMetadata metadata = gson.fromJson(jo.remove(METADATA_FIELD), EventMetadata.class);
 
-    // grab the remaining custom data and stuff it into a map
-    Map<String, Object> custom = gson.fromJson(jo, MAP_TYPE);
+    if (type instanceof ParameterizedType) {
+      /*
+      we want the generic parameter type of T captured by BusinessEventMapped<T> as that's
+      what'll we deser the json with before setting it into BusinessEventMapped.data. This is
+      expected to work as well for a T that is itself carrying a generic or a generic collection.
+      See EventMappedSupportTest.
+     */
+      ParameterizedType genericType = (ParameterizedType) type;
+      Type[] actualTypeArguments = genericType.getActualTypeArguments();
+      Type serdeType = actualTypeArguments[0];
+      T data = gson.fromJson(jo, serdeType);
+      return new BusinessEventMapped<>(data, metadata);
 
-    //noinspection unchecked
-    return new BusinessEventMapped().data(custom).metadata(metadata);
+    } else {
+      throw new IllegalArgumentException(
+          "Supplied type must be a parameterized BusinessEventMapped"
+              + type.getTypeName());
+    }
+
   }
 }

--- a/nakadi-java-client/src/main/java/nakadi/UndefinedEventMapped.java
+++ b/nakadi-java-client/src/main/java/nakadi/UndefinedEventMapped.java
@@ -11,22 +11,29 @@ import java.util.Objects;
  * object for it that isn't a HashMap or something like a raw string. </p>
  *
  * <p>{@link UndefinedEventMapped} works around this by marshalling custom fields found on the top
- * level JSON event into the {@link UndefinedEventMapped#data} Map. As such it doesn't exactly
+ * level JSON event into the {@link UndefinedEventMapped#data} field. As such it doesn't exactly
  * represent the data on the wire; instead the on wire representation is in the data field. </p>
  */
-public class UndefinedEventMapped implements Event {
+public class UndefinedEventMapped<T> implements Event {
 
-  private Map<String, Object> data;
+  private T data;
+
+  public UndefinedEventMapped() {
+  }
+
+  public UndefinedEventMapped(T data) {
+    this.data = data;
+  }
 
   /**
    * The mapped data
    */
-  public UndefinedEventMapped data(Map<String, Object> data) {
+  public UndefinedEventMapped<T> data(T data) {
     this.data = data;
     return this;
   }
 
-  public Map<String, Object> data() {
+  public T data() {
     return data;
   }
 

--- a/nakadi-java-client/src/test/java/nakadi/EventResourceTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/EventResourceTest.java
@@ -26,10 +26,10 @@ public class EventResourceTest {
   public void serdesUndefinedEventMapped() {
     EventResource eventResource = new EventResource(null);
 
-    UndefinedEventMapped ue = new UndefinedEventMapped();
     Map<String, Object> uemap = Maps.newHashMap();
     uemap.put("a", "1");
-    ue.data(uemap);
+    UndefinedEventMapped<Map<String, Object>> ue =
+        new UndefinedEventMapped<Map<String, Object>>().data(uemap);
     EventRecord<UndefinedEventMapped> er = new EventRecord<>("topic", ue);
     Map<String, Object> outmap = (Map<String, Object>) eventResource.mapEventRecordToSerdes(er);
     assertTrue(outmap.size() == 1);


### PR DESCRIPTION
This allows undefined and business events to be declared with
a generic type instead of a fixed Map<String, Object>. The
previous map option would force client users to reserialise
and deserialise the map to the domain object they're interested
in using.

Getting this to work such that a use can set their custom event
data into the "data" field and have that information lifted into
the top level JSON of the posted event, and have top level JSON
data received in a stream batch mapped down into the same "data"
requires some ugly serialization and deserialization (serdes)
hacks when those types are detected. That's the nature of the HTTP
API we have to work with. Otherwise we'd either have to, drop the
idea of having support for undefined and business, pass around
non-domain types (strings, map, json trees, bytes, etc)
that the client user would have to serdes themselves, or, just
give up on the API and let users represent the entirety of the
two categories as generics passed in and out of the client. We
choose to provide the types instead because a goal of the client
is to represent the full API.

This is a step towards a unified event model. UndefinedEventMapped,
BusinessEventMapped and DataChangeEvent now all have the same
signature for their "data" field.

For #18