### PR TITLE
Shutdown all stream processing executors.

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/ExecutorServiceSupport.java
+++ b/nakadi-java-client/src/main/java/nakadi/ExecutorServiceSupport.java
@@ -12,13 +12,6 @@ class ExecutorServiceSupport {
 
   private static final Logger logger = LoggerFactory.getLogger(NakadiClient.class.getSimpleName());
 
-  static ExecutorService newExecutorService() {
-    final ThreadFactory tf =
-        new ThreadFactoryBuilder().setNameFormat("nakadi-java").build();
-    // todo: cached thread pool maybe better for multi-shard handling
-    return Executors.newFixedThreadPool(2, tf);
-  }
-
   static void shutdown(ExecutorService executorService) {
     executorService.shutdown();
 


### PR DESCRIPTION
All 3 executors are now shutdown on stop() being called. This avoids
the JVM getting stuck on shutdown due to the executor threads.