### PR TITLE
Use the event read scope for event streaming.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,10 +2,11 @@
 
 #### 0.0.7
 
+- Change the TokenProvider interface to accept a scope; breaking interface change with 0.0.6
 - Add an extension jar, "nakadi-java-zign", for Zign tokens [#20](https://github.com/zalando-incubator/nakadi-java/issues/20)
-- Change the TokenProvider interface to accept a scope.
+- Make ExecutorServiceSupport public (allows the Zign extension to run in the background)
 - Use the event write scope when sending an event
-- Make ExecutorServiceSupport public
+- Use the event read scope when opening an event stream
 
 #### 0.0.6
 

--- a/nakadi-java-client/src/main/java/nakadi/StreamResourceSupport.java
+++ b/nakadi-java-client/src/main/java/nakadi/StreamResourceSupport.java
@@ -46,6 +46,7 @@ class StreamResourceSupport {
   static ResourceOptions buildResourceOptions(NakadiClient client, StreamConfiguration sc) {
     ResourceOptions options = ResourceSupport
         .options(APPLICATION_X_JSON_STREAM)
+        .scope(TokenProvider.NAKADI_EVENT_STREAM_READ)
         .tokenProvider(client.resourceTokenProvider());
 
     if (sc.isSubscriptionStream()) {

--- a/nakadi-java-client/src/test/java/nakadi/StreamResourceSupportTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/StreamResourceSupportTest.java
@@ -11,6 +11,22 @@ public class StreamResourceSupportTest {
       NakadiClient.newBuilder().baseURI("http://localhost:9080").build();
 
   @Test
+  public void testScope() {
+
+    assertEquals(
+        TokenProvider.NAKADI_EVENT_STREAM_READ,
+        StreamResourceSupport.buildResourceOptions(client,
+            new StreamConfiguration().eventTypeName("et")).scope()
+    );
+
+    assertEquals(
+        TokenProvider.NAKADI_EVENT_STREAM_READ,
+        StreamResourceSupport.buildResourceOptions(client,
+            new StreamConfiguration().subscriptionId("sub1")).scope()
+    );
+  }
+
+  @Test
   public void testUrlBuilder() {
 
     StreamConfiguration et = new StreamConfiguration().eventTypeName("et");


### PR DESCRIPTION
This will ask the token provider to supply the API scope for reading
events.