### PR TITLE
Simplify event sending methods.

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/EventMappedSupport.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventMappedSupport.java
@@ -16,7 +16,7 @@ class EventMappedSupport {
   private static final String METADATA_FIELD = "metadata";
   private static final GsonSupport gson = new GsonSupport();
 
-  static Object mapEventRecordToSerdes(EventRecord<? extends Event> eventRecord) {
+  static <T> Object mapEventRecordToSerdes(EventRecord<T> eventRecord) {
 
     if (eventRecord.event().getClass().isAssignableFrom(BusinessEventMapped.class)) {
 

--- a/nakadi-java-client/src/main/java/nakadi/EventRecord.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventRecord.java
@@ -7,7 +7,7 @@ import java.util.Objects;
  *
  * @param <E> the type of the event
  */
-public class EventRecord<E extends Event> {
+public class EventRecord<E> {
 
   private final String eventType;
   private final E event;

--- a/nakadi-java-client/src/main/java/nakadi/EventResource.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventResource.java
@@ -1,114 +1,11 @@
 package nakadi;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
+import java.util.Collection;
 
-public class EventResource {
+public interface EventResource {
 
-  private static final String PATH_EVENT_TYPES = "event-types";
-  private static final String PATH_COLLECTION = "events";
-  private static final String APPLICATION_JSON = "application/json";
+  <T> Response send(String eventTypeName, Collection<T> events);
 
-  private final NakadiClient client;
+  <T> Response send(String eventTypeName, T event);
 
-  public EventResource(NakadiClient client) {
-    this.client = client;
-  }
-
-  private static Response timed(Supplier<Response> sender, NakadiClient client, int eventCount) {
-    long start = System.nanoTime();
-    Response response = null;
-    try {
-      response = sender.get();
-      return response;
-    } finally {
-      if (response != null) {
-        emitMetric(client, response, eventCount);
-      }
-      client.metricCollector().duration(
-          MetricCollector.Timer.eventSend, (System.nanoTime() - start), TimeUnit.NANOSECONDS);
-    }
-  }
-
-  private static void emitMetric(NakadiClient client, Response response, int eventCount) {
-    if (response.statusCode() >= 200 && response.statusCode() <= 204) {
-      client.metricCollector().mark(MetricCollector.Meter.sent, eventCount);
-    }
-
-    if (response.statusCode() == 207) {
-      client.metricCollector().mark(MetricCollector.Meter.http207);
-    }
-  }
-
-  @SafeVarargs
-  public final <T extends Event> Response send(String eventTypeName, T... events) {
-    NakadiException.throwNonNull(eventTypeName, "Please provide an event type name");
-    NakadiException.throwNonNull(events, "Please provide one or more events");
-
-    return send(eventTypeName, Arrays.asList(events));
-  }
-
-  public final Response send(String eventTypeName, List<? extends Event> events) {
-    NakadiException.throwNonNull(eventTypeName, "Please provide an event type name");
-    NakadiException.throwNonNull(events, "Please provide one or more events");
-
-    if (events.size() == 0) {
-      throw new NakadiException(Problem.localProblem("event send called with zero events", ""));
-    }
-
-    List<EventRecord<? extends Event>> collect =
-        events.stream().map(e -> new EventRecord<>(eventTypeName, e)
-        ).collect(Collectors.toList());
-
-    return send(collect);
-  }
-
-  public final Response send(List<EventRecord<? extends Event>> events) {
-    NakadiException.throwNonNull(events, "Please provide one or more event records");
-
-    String topic = events.get(0).eventType();
-    List<Object> eventList =
-        events.stream().map(this::mapEventRecordToSerdes).collect(Collectors.toList());
-
-    return timed(() -> {
-          ResourceOptions options = options().scope(TokenProvider.NAKADI_EVENT_STREAM_WRITE);
-          return client.resourceProvider()
-              .newResource()
-              .requestThrowing(
-                  Resource.POST, collectionUri(topic).buildString(), options, eventList);
-        },
-        client,
-        eventList.size());
-  }
-
-  @SafeVarargs
-  public final Response send(EventRecord<? extends Event>... events) {
-    NakadiException.throwNonNull(events, "Please provide one or more event records");
-
-    if (events.length == 0) {
-      throw new NakadiException(Problem.localProblem("event send called with zero events", ""));
-    }
-
-    List<EventRecord<? extends Event>> records = Arrays.asList(events);
-    return send(records);
-  }
-
-  @VisibleForTesting
-  Object mapEventRecordToSerdes(EventRecord<? extends Event> er) {
-    return EventMappedSupport.mapEventRecordToSerdes(er);
-  }
-
-  private ResourceOptions options() {
-    return ResourceSupport.options(APPLICATION_JSON).tokenProvider(client.resourceTokenProvider());
-  }
-
-  private UriBuilder collectionUri(String topic) {
-    return UriBuilder.builder(client.baseURI())
-        .path(PATH_EVENT_TYPES)
-        .path(topic)
-        .path(PATH_COLLECTION);
-  }
 }

--- a/nakadi-java-client/src/main/java/nakadi/EventResourceReal.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventResourceReal.java
@@ -1,0 +1,104 @@
+package nakadi;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import jdk.nashorn.internal.ir.annotations.Immutable;
+
+public class EventResourceReal implements EventResource {
+
+  private static final String PATH_EVENT_TYPES = "event-types";
+  private static final String PATH_COLLECTION = "events";
+  private static final String APPLICATION_JSON = "application/json";
+
+  private final NakadiClient client;
+
+  public EventResourceReal(NakadiClient client) {
+    this.client = client;
+  }
+
+  private static Response timed(Supplier<Response> sender, NakadiClient client, int eventCount) {
+    long start = System.nanoTime();
+    Response response = null;
+    try {
+      response = sender.get();
+      return response;
+    } finally {
+      if (response != null) {
+        emitMetric(client, response, eventCount);
+      }
+      client.metricCollector().duration(
+          MetricCollector.Timer.eventSend, (System.nanoTime() - start), TimeUnit.NANOSECONDS);
+    }
+  }
+
+  private static void emitMetric(NakadiClient client, Response response, int eventCount) {
+    if (response.statusCode() >= 200 && response.statusCode() <= 204) {
+      client.metricCollector().mark(MetricCollector.Meter.sent, eventCount);
+    }
+
+    if (response.statusCode() == 207) {
+      client.metricCollector().mark(MetricCollector.Meter.http207);
+    }
+  }
+
+  @Override
+  public <T> Response send(String eventTypeName, T event) {
+    NakadiException.throwNonNull(eventTypeName, "Please provide an event type name");
+    NakadiException.throwNonNull(event, "Please provide an event");
+    return send(eventTypeName, ImmutableList.of(event));
+  }
+
+  @Override
+  public final <T> Response send(String eventTypeName, Collection<T> events) {
+    NakadiException.throwNonNull(eventTypeName, "Please provide an event type name");
+    NakadiException.throwNonNull(events, "Please provide one or more events");
+
+    if (events.size() == 0) {
+      throw new NakadiException(Problem.localProblem("event send called with zero events", ""));
+    }
+
+    List<EventRecord<T>> collect =
+        events.stream().map(e -> new EventRecord<>(eventTypeName, e)).collect(Collectors.toList());
+
+    return send(collect);
+  }
+
+  private <T> Response send(List<EventRecord<T>> events) {
+    NakadiException.throwNonNull(events, "Please provide one or more event records");
+
+    String topic = events.get(0).eventType();
+    List<Object> eventList =
+        events.stream().map(this::mapEventRecordToSerdes).collect(Collectors.toList());
+
+    return timed(() -> {
+          ResourceOptions options = options().scope(TokenProvider.NAKADI_EVENT_STREAM_WRITE);
+          return client.resourceProvider()
+              .newResource()
+              .requestThrowing(
+                  Resource.POST, collectionUri(topic).buildString(), options, eventList);
+        },
+        client,
+        eventList.size());
+  }
+
+  @VisibleForTesting
+  <T> Object mapEventRecordToSerdes(EventRecord<T> er) {
+    return EventMappedSupport.mapEventRecordToSerdes(er);
+  }
+
+  private ResourceOptions options() {
+    return ResourceSupport.options(APPLICATION_JSON).tokenProvider(client.resourceTokenProvider());
+  }
+
+  private UriBuilder collectionUri(String topic) {
+    return UriBuilder.builder(client.baseURI())
+        .path(PATH_EVENT_TYPES)
+        .path(topic)
+        .path(PATH_COLLECTION);
+  }
+}

--- a/nakadi-java-client/src/main/java/nakadi/Resources.java
+++ b/nakadi-java-client/src/main/java/nakadi/Resources.java
@@ -46,7 +46,7 @@ public class Resources {
    * @return a resource for working with events
    */
   public EventResource events() {
-    return new EventResource(client);
+    return new EventResourceReal(client);
   }
 
   /**

--- a/nakadi-java-client/src/test/java/nakadi/EventResourceRealTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/EventResourceRealTest.java
@@ -2,8 +2,6 @@ package nakadi;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -14,14 +12,13 @@ import org.mockito.Matchers;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class EventResourceTest {
+public class EventResourceRealTest {
 
   static class Happened {
     String id;
@@ -65,11 +62,11 @@ public class EventResourceTest {
     when(client.resourceProvider().newResource()).thenReturn(r);
 
     try {
-      new EventResource(client).send("foo", new Event<Happened>() {
+      new EventResourceReal(client).send("foo", Lists.newArrayList(new Event<Happened>() {
         public Happened data() {
           return new Happened("a");
         }
-      });
+      }));
     } catch(NetworkException | NotFoundException ignored) {
     }
 
@@ -87,7 +84,7 @@ public class EventResourceTest {
 
   @Test
   public void serdesDomain() {
-    EventResource eventResource = new EventResource(null);
+    EventResourceReal eventResource = new EventResourceReal(null);
 
     EventThing et = new EventThing("a", "b");
     EventRecord<EventThing> er = new EventRecord<>("topic", et);
@@ -99,7 +96,7 @@ public class EventResourceTest {
 
   @Test
   public void serdesUndefinedEventMapped() {
-    EventResource eventResource = new EventResource(null);
+    EventResourceReal eventResource = new EventResourceReal(null);
 
     Map<String, Object> uemap = Maps.newHashMap();
     uemap.put("a", "1");
@@ -114,7 +111,7 @@ public class EventResourceTest {
 
   @Test
   public void serdesBusinessEventMapped() {
-    EventResource eventResource = new EventResource(null);
+    EventResourceReal eventResource = new EventResourceReal(null);
 
     BusinessEventMapped be = new BusinessEventMapped();
     EventMetadata em = new EventMetadata();

--- a/nakadi-java-zign/src/test/java/nakadi/token/zign/TokenProviderZignTest.java
+++ b/nakadi-java-zign/src/test/java/nakadi/token/zign/TokenProviderZignTest.java
@@ -15,6 +15,7 @@ public class TokenProviderZignTest {
     }
 
     try {
+      //noinspection ConfusingArgumentToVarargsMethod
       TokenProviderZign.newBuilder().scopes(null);
       fail();
     } catch (IllegalArgumentException ignored) {


### PR DESCRIPTION
This replaces the list and varargs options with a list and
and a single event send methods. The varargs were handy but
provided too many call options and also causing warnings
because the generic event type wasn't reifable (since a
varargs list is converted to a T[] which wipes the type
information and would be illegal if we actually wrote that
out; but since the compiler is doing it we get a warning
instead).

The constraint that the send methods take a wilcard extending
Event has also been lifted, to allow any type to be used.