### PR TITLE
Allow scopes and custom scopes to be set for event types.

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/EventTypeCollection.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventTypeCollection.java
@@ -7,10 +7,10 @@ import java.util.List;
  */
 public class EventTypeCollection extends ResourceCollection<EventType> {
 
-  private final EventTypeResource eventTypeResource;
+  private final EventTypeResourceReal eventTypeResource;
 
   public EventTypeCollection(List<EventType> items, List<ResourceLink> links,
-      EventTypeResource eventTypeResource) {
+      EventTypeResourceReal eventTypeResource) {
     super(items, links);
     this.eventTypeResource = eventTypeResource;
   }

--- a/nakadi-java-client/src/main/java/nakadi/EventTypeResource.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventTypeResource.java
@@ -1,28 +1,17 @@
 package nakadi;
 
-import com.google.common.collect.Lists;
-import com.google.gson.reflect.TypeToken;
-import java.lang.reflect.Type;
-import java.util.List;
-
 /**
  * Supports API operations related to event types.
  */
-public class EventTypeResource {
+public interface EventTypeResource {
 
-  private static final String PATH_EVENT_TYPES = "event-types";
-  private static final String PATH_PARTITIONS = "partitions";
-  private static final String APPLICATION_JSON = "application/json";
-  private static final Type TYPE = new TypeToken<List<EventType>>() {
-  }.getType();
-  private static final Type TYPE_P = new TypeToken<List<Partition>>() {
-  }.getType();
-
-  private final NakadiClient client;
-
-  EventTypeResource(NakadiClient client) {
-    this.client = client;
-  }
+  /**
+   * Set the OAuth scope to be used for the request. This can be reset between requests.
+   *
+   * @param scope the OAuth scope to be used for the request
+   * @return this
+   */
+  EventTypeResource scope(String scope);
 
   /**
    * Create an event type.
@@ -36,12 +25,9 @@ public class EventTypeResource {
    * @throws RateLimitException
    * @throws NakadiException
    */
-  public Response create(EventType eventType)
+  Response create(EventType eventType)
       throws AuthorizationException, ClientException, ServerException, InvalidException,
-      RateLimitException, NakadiException {
-    return client.resourceProvider().newResource()
-        .requestThrowing(Resource.POST, collectionUri().buildString(), prepareOptions(), eventType);
-  }
+      RateLimitException, NakadiException;
 
   /**
    * Update an existing event type
@@ -53,37 +39,25 @@ public class EventTypeResource {
    * @throws RateLimitException
    * @throws NakadiException
    */
-  public Response update(EventType eventType)
+  Response update(EventType eventType)
       throws AuthorizationException, ClientException, ServerException, InvalidException,
-      RateLimitException, NakadiException {
-    String url = collectionUri().path(eventType.name()).buildString();
-    return client.resourceProvider().newResource()
-        .requestThrowing(Resource.PUT, url, prepareOptions(), eventType);
-  }
+      RateLimitException, NakadiException;
 
   /**
    * @param eventTypeName the event type name
    */
-  public EventType findByName(String eventTypeName)
+  EventType findByName(String eventTypeName)
       throws AuthorizationException, ClientException, ServerException, InvalidException,
-      RateLimitException, NakadiException {
-    String url = collectionUri().path(eventTypeName).buildString();
-    return client.resourceProvider().newResource()
-        .requestThrowing(Resource.GET, url, prepareOptions(), EventType.class);
-  }
+      RateLimitException, NakadiException;
 
   /**
    * Successful deletes return 200 and no body.
    *
    * @return a http response that will have no body
    */
-  public Response delete(String eventTypeName)
+  Response delete(String eventTypeName)
       throws AuthorizationException, ClientException, ServerException, InvalidException,
-      RateLimitException, NakadiException {
-    String url = collectionUri().path(eventTypeName).buildString();
-    return client.resourceProvider().newResource()
-        .requestThrowing(Resource.DELETE, url, prepareOptions());
-  }
+      RateLimitException, NakadiException;
 
   /**
    * @return a collection of event types
@@ -94,58 +68,38 @@ public class EventTypeResource {
    * @throws RateLimitException
    * @throws NakadiException
    */
-  public EventTypeCollection list()
+  EventTypeCollection list()
       throws AuthorizationException, ClientException, ServerException, InvalidException,
-      RateLimitException, NakadiException {
-    return loadPage(collectionUri().buildString());
-  }
+      RateLimitException, NakadiException;
 
-  public PartitionCollection partitions(String eventTypeName)
+  /**
+   * Fetch the partitions for an event type.
+   *
+   * @param eventTypeName the event type
+   * @throws AuthorizationException
+   * @throws ClientException
+   * @throws ServerException
+   * @throws InvalidException
+   * @throws RateLimitException
+   * @throws NakadiException
+   */
+  PartitionCollection partitions(String eventTypeName)
       throws AuthorizationException, ClientException, ServerException, InvalidException,
-      RateLimitException, NakadiException {
-    return loadPartitionPage(
-        collectionUri().path(eventTypeName).path(PATH_PARTITIONS).buildString());
-  }
+      RateLimitException, NakadiException;
 
-  public Partition partition(String eventTypeName, String partitionId)
+  /**
+   * Fetch the partition for an event type.
+   *
+   * @param eventTypeName the event type
+   * @param partitionId the partition
+   * @throws AuthorizationException
+   * @throws ClientException
+   * @throws ServerException
+   * @throws InvalidException
+   * @throws RateLimitException
+   * @throws NakadiException
+   */
+  Partition partition(String eventTypeName, String partitionId)
       throws AuthorizationException, ClientException, ServerException, InvalidException,
-      RateLimitException, NakadiException {
-    final String url =
-        collectionUri().path(eventTypeName).path(PATH_PARTITIONS).path(partitionId).buildString();
-    return client.resourceProvider().newResource()
-        .requestThrowing(Resource.GET, url, prepareOptions(), Partition.class);
-  }
-
-  EventTypeCollection loadPage(String url) {
-    Response response = client.resourceProvider().newResource()
-        .requestThrowing(Resource.GET, url,
-            ResourceSupport.options(APPLICATION_JSON)
-                .tokenProvider(client.resourceTokenProvider()));
-
-    List<EventType> collection =
-        client.jsonSupport().fromJson(response.responseBody().asString(), TYPE);
-
-    return new EventTypeCollection(collection, Lists.newArrayList(), this);
-  }
-
-  PartitionCollection loadPartitionPage(String url) {
-    Response response = client.resourceProvider().newResource()
-        .requestThrowing(Resource.GET, url,
-            ResourceSupport.options(APPLICATION_JSON)
-                .tokenProvider(client.resourceTokenProvider()));
-
-    List<Partition> collection =
-        client.jsonSupport().fromJson(response.responseBody().asString(), TYPE_P);
-
-    return new PartitionCollection(collection, Lists.newArrayList(), this);
-  }
-
-  private ResourceOptions prepareOptions() {
-    return ResourceSupport.options(APPLICATION_JSON)
-        .tokenProvider(client.resourceTokenProvider());
-  }
-
-  private UriBuilder collectionUri() {
-    return UriBuilder.builder(client.baseURI()).path(PATH_EVENT_TYPES);
-  }
+      RateLimitException, NakadiException;
 }

--- a/nakadi-java-client/src/main/java/nakadi/EventTypeResourceReal.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventTypeResourceReal.java
@@ -1,0 +1,125 @@
+package nakadi;
+
+import com.google.common.collect.Lists;
+import com.google.gson.reflect.TypeToken;
+import java.lang.reflect.Type;
+import java.util.List;
+
+class EventTypeResourceReal implements EventTypeResource {
+
+  private static final String PATH_EVENT_TYPES = "event-types";
+  private static final String PATH_PARTITIONS = "partitions";
+  private static final String APPLICATION_JSON = "application/json";
+  private static final Type TYPE = new TypeToken<List<EventType>>() {
+  }.getType();
+  private static final Type TYPE_P = new TypeToken<List<Partition>>() {
+  }.getType();
+
+  private final NakadiClient client;
+  private String scope;
+
+  EventTypeResourceReal(NakadiClient client) {
+    this.client = client;
+  }
+
+  @Override public EventTypeResource scope(String scope) {
+    this.scope = scope;
+    return this;
+  }
+
+  @Override public Response create(EventType eventType)
+      throws AuthorizationException, ClientException, ServerException, InvalidException,
+      RateLimitException, NakadiException {
+    ResourceOptions options = prepareOptions(TokenProvider.NAKADI_EVENT_TYPE_WRITE);
+    return client.resourceProvider().newResource()
+        .requestThrowing(Resource.POST, collectionUri().buildString(), options, eventType);
+  }
+
+  @Override public Response update(EventType eventType)
+      throws AuthorizationException, ClientException, ServerException, InvalidException,
+      RateLimitException, NakadiException {
+    String url = collectionUri().path(eventType.name()).buildString();
+    ResourceOptions options = prepareOptions(TokenProvider.NAKADI_EVENT_TYPE_WRITE);
+    return client.resourceProvider().newResource()
+        .requestThrowing(Resource.PUT, url, options, eventType);
+  }
+
+  @Override public EventType findByName(String eventTypeName)
+      throws AuthorizationException, ClientException, ServerException, InvalidException,
+      RateLimitException, NakadiException {
+    String url = collectionUri().path(eventTypeName).buildString();
+    // filebug: no scope defined on this resource; work with NAKADI_EVENT_STREAM_READ for now
+    ResourceOptions options = prepareOptions(TokenProvider.NAKADI_EVENT_STREAM_READ);
+    return client.resourceProvider().newResource()
+        .requestThrowing(Resource.GET, url, options, EventType.class);
+  }
+
+  @Override public Response delete(String eventTypeName)
+      throws AuthorizationException, ClientException, ServerException, InvalidException,
+      RateLimitException, NakadiException {
+    String url = collectionUri().path(eventTypeName).buildString();
+    ResourceOptions options = prepareOptions(TokenProvider.NAKADI_CONFIG_WRITE);
+    return client.resourceProvider().newResource()
+        .requestThrowing(Resource.DELETE, url, options);
+  }
+
+  @Override public EventTypeCollection list()
+      throws AuthorizationException, ClientException, ServerException, InvalidException,
+      RateLimitException, NakadiException {
+    return loadPage(collectionUri().buildString());
+  }
+
+  @Override public PartitionCollection partitions(String eventTypeName)
+      throws AuthorizationException, ClientException, ServerException, InvalidException,
+      RateLimitException, NakadiException {
+    return loadPartitionPage(
+        collectionUri().path(eventTypeName).path(PATH_PARTITIONS).buildString());
+  }
+
+  @Override public Partition partition(String eventTypeName, String partitionId)
+      throws AuthorizationException, ClientException, ServerException, InvalidException,
+      RateLimitException, NakadiException {
+    final String url =
+        collectionUri().path(eventTypeName).path(PATH_PARTITIONS).path(partitionId).buildString();
+    ResourceOptions options = prepareOptions(TokenProvider.NAKADI_EVENT_STREAM_READ);
+    return client.resourceProvider().newResource()
+        .requestThrowing(Resource.GET, url, options, Partition.class);
+  }
+
+  String applyScope(String fallbackScope) {
+    return scope == null ? fallbackScope: scope;
+  }
+
+  EventTypeCollection loadPage(String url) {
+    // filebug: no scope defined on this resource; work with NAKADI_EVENT_STREAM_READ for now
+    ResourceOptions options = prepareOptions(TokenProvider.NAKADI_EVENT_STREAM_READ);
+    Response response = client.resourceProvider().newResource()
+        .requestThrowing(Resource.GET, url, options);
+
+    List<EventType> collection =
+        client.jsonSupport().fromJson(response.responseBody().asString(), TYPE);
+
+    return new EventTypeCollection(collection, Lists.newArrayList(), this);
+  }
+
+  PartitionCollection loadPartitionPage(String url) {
+    ResourceOptions options = prepareOptions(TokenProvider.NAKADI_EVENT_STREAM_READ);
+    Response response = client.resourceProvider().newResource()
+        .requestThrowing(Resource.GET, url, options);
+
+    List<Partition> collection =
+        client.jsonSupport().fromJson(response.responseBody().asString(), TYPE_P);
+
+    return new PartitionCollection(collection, Lists.newArrayList(), this);
+  }
+
+  private ResourceOptions prepareOptions(String fallbackScope) {
+    return ResourceSupport.options(APPLICATION_JSON)
+        .tokenProvider(client.resourceTokenProvider())
+        .scope(applyScope(fallbackScope)); // use the set scope or fallback
+  }
+
+  private UriBuilder collectionUri() {
+    return UriBuilder.builder(client.baseURI()).path(PATH_EVENT_TYPES);
+  }
+}

--- a/nakadi-java-client/src/main/java/nakadi/PartitionCollection.java
+++ b/nakadi-java-client/src/main/java/nakadi/PartitionCollection.java
@@ -7,10 +7,10 @@ import java.util.List;
  */
 public class PartitionCollection extends ResourceCollection<Partition> {
 
-  private final EventTypeResource eventTypeResource;
+  private final EventTypeResourceReal eventTypeResource;
 
-  public PartitionCollection(List<Partition> items, List<ResourceLink> links,
-      EventTypeResource eventTypeResource) {
+  PartitionCollection(List<Partition> items, List<ResourceLink> links,
+      EventTypeResourceReal eventTypeResource) {
     super(items, links);
     this.eventTypeResource = eventTypeResource;
   }

--- a/nakadi-java-client/src/main/java/nakadi/Resources.java
+++ b/nakadi-java-client/src/main/java/nakadi/Resources.java
@@ -37,7 +37,7 @@ public class Resources {
    * @return a resource for working with event types
    */
   public EventTypeResource eventTypes() {
-    return new EventTypeResource(client);
+    return new EventTypeResourceReal(client);
   }
 
   /**

--- a/nakadi-java-client/src/test/java/nakadi/EventTypeResourceRealTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/EventTypeResourceRealTest.java
@@ -1,0 +1,423 @@
+package nakadi;
+
+import java.util.Optional;
+import okhttp3.OkHttpClient;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Matchers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class EventTypeResourceRealTest {
+
+  @Test
+  public void createWithScope() {
+
+    EventType et2 = buildEventType();
+
+    final boolean[] askedForNAKADI_EVENT_TYPE_WRITE = {false};
+    final boolean[] askedForCustomToken = {false};
+    String customScope = "custom";
+
+    NakadiClient client = spy(NakadiClient.newBuilder()
+        .baseURI("http://localhost:9080")
+        .tokenProvider(scope -> {
+          if (TokenProvider.NAKADI_EVENT_TYPE_WRITE.equals(scope)) {
+            askedForNAKADI_EVENT_TYPE_WRITE[0] = true;
+          }
+
+          if (customScope.equals(scope)) {
+            askedForCustomToken[0] = true;
+          }
+
+          return Optional.empty();
+        })
+        .build());
+
+    Resource r0 = spy(new OkHttpResource(
+        new OkHttpClient.Builder().build(),
+        new GsonSupport(),
+        mock(MetricCollector.class)));
+
+    when(client.resourceProvider()).thenReturn(mock(ResourceProvider.class));
+    when(client.resourceProvider().newResource()).thenReturn(r0);
+
+    try {
+      new EventTypeResourceReal(client)
+          .update(et2);
+    } catch (NetworkException | NotFoundException ignored) {
+    }
+
+    ArgumentCaptor<ResourceOptions> options = ArgumentCaptor.forClass(ResourceOptions.class);
+
+    verify(r0, times(1)).requestThrowing(
+        Matchers.eq(Resource.PUT),
+        Matchers.eq("http://localhost:9080/event-types/" + et2.name()),
+        options.capture(),
+        Matchers.eq(et2)
+    );
+
+    assertEquals(TokenProvider.NAKADI_EVENT_TYPE_WRITE, options.getValue().scope());
+    assertTrue(askedForNAKADI_EVENT_TYPE_WRITE[0]);
+    assertFalse(askedForCustomToken[0]);
+
+    Resource r1 = spy(new OkHttpResource(
+        new OkHttpClient.Builder().build(),
+        new GsonSupport(),
+        mock(MetricCollector.class)));
+
+    when(client.resourceProvider()).thenReturn(mock(ResourceProvider.class));
+    when(client.resourceProvider().newResource()).thenReturn(r1);
+
+    try {
+      new EventTypeResourceReal(client)
+          .scope(customScope)
+          .update(et2);
+    } catch (NetworkException | NotFoundException ignored) {
+    }
+
+    options = ArgumentCaptor.forClass(ResourceOptions.class);
+
+    verify(r1, times(1)).requestThrowing(
+        Matchers.eq(Resource.PUT),
+        Matchers.eq("http://localhost:9080/event-types/" + et2.name()),
+        options.capture(),
+        Matchers.eq(et2)
+    );
+
+    assertEquals(customScope, options.getValue().scope());
+    assertTrue(askedForCustomToken[0]);
+  }
+
+  @Test
+  public void updateWithScope() {
+
+    EventType et2 = buildEventType();
+
+    final boolean[] askedForNAKADI_EVENT_TYPE_WRITE = {false};
+    final boolean[] askedForCustomToken = {false};
+    String customScope = "custom";
+
+    NakadiClient client = spy(NakadiClient.newBuilder()
+        .baseURI("http://localhost:9080")
+        .tokenProvider(scope -> {
+          if (TokenProvider.NAKADI_EVENT_TYPE_WRITE.equals(scope)) {
+            askedForNAKADI_EVENT_TYPE_WRITE[0] = true;
+          }
+
+          if (customScope.equals(scope)) {
+            askedForCustomToken[0] = true;
+          }
+
+          return Optional.empty();
+        })
+        .build());
+
+    Resource r0 = spy(new OkHttpResource(
+        new OkHttpClient.Builder().build(),
+        new GsonSupport(),
+        mock(MetricCollector.class)));
+
+    when(client.resourceProvider()).thenReturn(mock(ResourceProvider.class));
+    when(client.resourceProvider().newResource()).thenReturn(r0);
+
+    try {
+      new EventTypeResourceReal(client)
+          .create(et2);
+    } catch (NetworkException | NotFoundException ignored) {
+    }
+
+    ArgumentCaptor<ResourceOptions> options = ArgumentCaptor.forClass(ResourceOptions.class);
+
+    verify(r0, times(1)).requestThrowing(
+        Matchers.eq(Resource.POST),
+        Matchers.eq("http://localhost:9080/event-types"),
+        options.capture(),
+        Matchers.eq(et2)
+    );
+
+    assertEquals(TokenProvider.NAKADI_EVENT_TYPE_WRITE, options.getValue().scope());
+    assertTrue(askedForNAKADI_EVENT_TYPE_WRITE[0]);
+    assertFalse(askedForCustomToken[0]);
+
+    Resource r1 = spy(new OkHttpResource(
+        new OkHttpClient.Builder().build(),
+        new GsonSupport(),
+        mock(MetricCollector.class)));
+
+    when(client.resourceProvider()).thenReturn(mock(ResourceProvider.class));
+    when(client.resourceProvider().newResource()).thenReturn(r1);
+
+    try {
+      new EventTypeResourceReal(client)
+          .scope(customScope)
+          .create(et2);
+    } catch (NetworkException | NotFoundException ignored) {
+    }
+
+    options = ArgumentCaptor.forClass(ResourceOptions.class);
+
+    verify(r1, times(1)).requestThrowing(
+        Matchers.eq(Resource.POST),
+        Matchers.eq("http://localhost:9080/event-types"),
+        options.capture(),
+        Matchers.eq(et2)
+    );
+
+    assertEquals(customScope, options.getValue().scope());
+    assertTrue(askedForCustomToken[0]);
+  }
+
+  private EventType buildEventType() {
+    return new EventType()
+        .category(EventType.Category.data)
+        .name("et-1-" + System.currentTimeMillis() / 1000)
+        .owningApplication("acme")
+        .partitionStrategy(EventType.PARTITION_HASH)
+        .enrichmentStrategy(EventType.ENRICHMENT_METADATA)
+        .partitionKeyFields("id")
+        .schema(new EventTypeSchema().schema(
+            "{ \"properties\": { \"id\": { \"type\": \"string\" } } }"));
+  }
+
+  @Test
+  public void listWithScope() {
+
+    final boolean[] askedForNAKADI_EVENT_STREAM_READ = {false};
+    final boolean[] askedForCustomToken = {false};
+    String customScope = "custom";
+
+    NakadiClient client = spy(NakadiClient.newBuilder()
+        .baseURI("http://localhost:9080")
+        .tokenProvider(scope -> {
+          if (TokenProvider.NAKADI_EVENT_STREAM_READ.equals(scope)) {
+            askedForNAKADI_EVENT_STREAM_READ[0] = true;
+          }
+
+          if (customScope.equals(scope)) {
+            askedForCustomToken[0] = true;
+          }
+
+          return Optional.empty();
+        })
+        .build());
+
+    Resource r0 = spy(new OkHttpResource(
+        new OkHttpClient.Builder().build(),
+        new GsonSupport(),
+        mock(MetricCollector.class)));
+
+    when(client.resourceProvider()).thenReturn(mock(ResourceProvider.class));
+    when(client.resourceProvider().newResource()).thenReturn(r0);
+
+    try {
+      new EventTypeResourceReal(client).list();
+    } catch (NetworkException | NotFoundException ignored) {
+    }
+
+    ArgumentCaptor<ResourceOptions> options = ArgumentCaptor.forClass(ResourceOptions.class);
+
+    verify(r0, times(1)).requestThrowing(
+        Matchers.eq(Resource.GET),
+        Matchers.eq("http://localhost:9080/event-types"),
+        options.capture()
+    );
+
+    assertEquals(TokenProvider.NAKADI_EVENT_STREAM_READ, options.getValue().scope());
+    assertTrue(askedForNAKADI_EVENT_STREAM_READ[0]);
+    assertFalse(askedForCustomToken[0]);
+
+    Resource r1 = spy(new OkHttpResource(
+        new OkHttpClient.Builder().build(),
+        new GsonSupport(),
+        mock(MetricCollector.class)));
+
+    when(client.resourceProvider()).thenReturn(mock(ResourceProvider.class));
+    when(client.resourceProvider().newResource()).thenReturn(r1);
+
+    try {
+      new EventTypeResourceReal(client).scope(customScope).list();
+    } catch (NetworkException | NotFoundException ignored) {
+    }
+
+    options = ArgumentCaptor.forClass(ResourceOptions.class);
+
+    verify(r1, times(1)).requestThrowing(
+        Matchers.eq(Resource.GET),
+        Matchers.eq("http://localhost:9080/event-types"),
+        options.capture());
+
+    assertEquals(customScope, options.getValue().scope());
+    assertTrue(askedForCustomToken[0]);
+  }
+
+  @Test
+  public void findWithScope() {
+
+    final boolean[] askedForNAKADI_EVENT_STREAM_READ = {false};
+    final boolean[] askedForCustomToken = {false};
+    String customScope = "custom";
+
+    NakadiClient client = spy(NakadiClient.newBuilder()
+        .baseURI("http://localhost:9080")
+        .tokenProvider(scope -> {
+          if (TokenProvider.NAKADI_EVENT_STREAM_READ.equals(scope)) {
+            askedForNAKADI_EVENT_STREAM_READ[0] = true;
+          }
+
+          if (customScope.equals(scope)) {
+            askedForCustomToken[0] = true;
+          }
+
+          return Optional.empty();
+        })
+        .build());
+
+    Resource r1 = spy(new OkHttpResource(
+        new OkHttpClient.Builder().build(),
+        new GsonSupport(),
+        mock(MetricCollector.class)));
+
+    when(client.resourceProvider()).thenReturn(mock(ResourceProvider.class));
+    when(client.resourceProvider().newResource()).thenReturn(r1);
+
+    try {
+      assertFalse(askedForCustomToken[0]);
+      assertFalse(askedForNAKADI_EVENT_STREAM_READ[0]);
+
+      new EventTypeResourceReal(client)
+          .findByName("foo");
+    } catch (NetworkException | NotFoundException ignored) {
+    }
+
+    ArgumentCaptor<ResourceOptions> options = ArgumentCaptor.forClass(ResourceOptions.class);
+
+    options = ArgumentCaptor.forClass(ResourceOptions.class);
+
+    verify(r1, times(1)).requestThrowing(
+        Matchers.eq(Resource.GET),
+        Matchers.eq("http://localhost:9080/event-types/foo"),
+        options.capture(),
+        Matchers.eq(EventType.class));
+
+    assertEquals(TokenProvider.NAKADI_EVENT_STREAM_READ, options.getValue().scope());
+    assertFalse(askedForCustomToken[0]);
+    assertTrue(askedForNAKADI_EVENT_STREAM_READ[0]);
+
+    Resource r2 = spy(new OkHttpResource(
+        new OkHttpClient.Builder().build(),
+        new GsonSupport(),
+        mock(MetricCollector.class)));
+
+    when(client.resourceProvider()).thenReturn(mock(ResourceProvider.class));
+    when(client.resourceProvider().newResource()).thenReturn(r2);
+
+    try {
+      askedForCustomToken[0] = false;
+      assertFalse(askedForCustomToken[0]);
+
+      new EventTypeResourceReal(client)
+          .scope(customScope)
+          .findByName("foo");
+    } catch (NetworkException | NotFoundException ignored) {
+    }
+
+    options = ArgumentCaptor.forClass(ResourceOptions.class);
+
+    verify(r2, times(1)).requestThrowing(
+        Matchers.eq(Resource.GET),
+        Matchers.eq("http://localhost:9080/event-types/foo"),
+        options.capture(),
+        Matchers.eq(EventType.class));
+
+    assertEquals(customScope, options.getValue().scope());
+    assertTrue(askedForCustomToken[0]);
+  }
+
+  @Test
+  public void deleteWithScope() {
+
+    final boolean[] askedForNAKADI_CONFIG_WRITE = {false};
+    final boolean[] askedForCustomToken = {false};
+    String customScope = "custom";
+
+    NakadiClient client = spy(NakadiClient.newBuilder()
+        .baseURI("http://localhost:9080")
+        .tokenProvider(scope -> {
+          if (TokenProvider.NAKADI_CONFIG_WRITE.equals(scope)) {
+            askedForNAKADI_CONFIG_WRITE[0] = true;
+          }
+
+          if (customScope.equals(scope)) {
+            askedForCustomToken[0] = true;
+          }
+
+          return Optional.empty();
+        })
+        .build());
+
+    Resource r1 = spy(new OkHttpResource(
+        new OkHttpClient.Builder().build(),
+        new GsonSupport(),
+        mock(MetricCollector.class)));
+
+    when(client.resourceProvider()).thenReturn(mock(ResourceProvider.class));
+    when(client.resourceProvider().newResource()).thenReturn(r1);
+
+    try {
+      assertFalse(askedForCustomToken[0]);
+      assertFalse(askedForNAKADI_CONFIG_WRITE[0]);
+
+      new EventTypeResourceReal(client).delete("foo");
+    } catch (NetworkException | NotFoundException ignored) {
+    }
+
+    ArgumentCaptor<ResourceOptions> options = ArgumentCaptor.forClass(ResourceOptions.class);
+
+    options = ArgumentCaptor.forClass(ResourceOptions.class);
+
+    verify(r1, times(1)).requestThrowing(
+        Matchers.eq(Resource.DELETE),
+        Matchers.eq("http://localhost:9080/event-types/foo"),
+        options.capture());
+
+    assertEquals(TokenProvider.NAKADI_CONFIG_WRITE, options.getValue().scope());
+    assertFalse(askedForCustomToken[0]);
+    assertTrue(askedForNAKADI_CONFIG_WRITE[0]);
+
+    Resource r2 = spy(new OkHttpResource(
+        new OkHttpClient.Builder().build(),
+        new GsonSupport(),
+        mock(MetricCollector.class)));
+
+    when(client.resourceProvider()).thenReturn(mock(ResourceProvider.class));
+    when(client.resourceProvider().newResource()).thenReturn(r2);
+
+    try {
+      askedForCustomToken[0] = false;
+      assertFalse(askedForCustomToken[0]);
+
+      new EventTypeResourceReal(client)
+          .scope(customScope)
+          .delete("foo");
+    } catch (NetworkException | NotFoundException ignored) {
+    }
+
+    options = ArgumentCaptor.forClass(ResourceOptions.class);
+
+    verify(r2, times(1)).requestThrowing(
+        Matchers.eq(Resource.DELETE),
+        Matchers.eq("http://localhost:9080/event-types/foo"),
+        options.capture());
+
+    assertEquals(customScope, options.getValue().scope());
+    assertTrue(askedForCustomToken[0]);
+  }
+}


### PR DESCRIPTION
This uses the default scopes where documented, and a best guess
where not documented for event type scopes. The scopes() method
on the EventTypeResource allows a custom scope to be passed in
and can be changed per request invocation. If there's no custom
scope, the default for the request is applied.

For #48.