### PR TITLE
Allow custom scopes to be set for event sending.

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/EventResource.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventResource.java
@@ -4,6 +4,14 @@ import java.util.Collection;
 
 public interface EventResource {
 
+  /**
+   * Set the OAuth scope to be used for the request. This can be reset between requests.
+   *
+   * @param scope the OAuth scope to be used for the request
+   * @return this
+   */
+  EventResource scope(String scope);
+
   <T> Response send(String eventTypeName, Collection<T> events);
 
   <T> Response send(String eventTypeName, T event);


### PR DESCRIPTION
The scopes() method on the EventResource allows a custom scope to be passed in
and can be changed per request invocation. If there's no custom scope, the
default for the request is applied.

For #48.