### PR TITLE
Allow custom scopes to be set for event streaming.

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/StreamResourceSupport.java
+++ b/nakadi-java-client/src/main/java/nakadi/StreamResourceSupport.java
@@ -43,10 +43,11 @@ class StreamResourceSupport {
    * single line JSON encoding of {@link StreamConfiguration#cursors()} if the configuration
    * is a basic event stream.
    */
-  static ResourceOptions buildResourceOptions(NakadiClient client, StreamConfiguration sc) {
+  static ResourceOptions buildResourceOptions(NakadiClient client, StreamConfiguration sc,
+     String scope) {
     ResourceOptions options = ResourceSupport
         .options(APPLICATION_X_JSON_STREAM)
-        .scope(TokenProvider.NAKADI_EVENT_STREAM_READ)
+        .scope(Optional.ofNullable(scope).orElseGet(() -> TokenProvider.NAKADI_EVENT_STREAM_READ))
         .tokenProvider(client.resourceTokenProvider());
 
     if (sc.isSubscriptionStream()) {

--- a/nakadi-java-client/src/test/java/nakadi/StreamResourceSupportTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/StreamResourceSupportTest.java
@@ -16,14 +16,27 @@ public class StreamResourceSupportTest {
     assertEquals(
         TokenProvider.NAKADI_EVENT_STREAM_READ,
         StreamResourceSupport.buildResourceOptions(client,
-            new StreamConfiguration().eventTypeName("et")).scope()
+            new StreamConfiguration().eventTypeName("et"), null).scope()
     );
 
     assertEquals(
         TokenProvider.NAKADI_EVENT_STREAM_READ,
         StreamResourceSupport.buildResourceOptions(client,
-            new StreamConfiguration().subscriptionId("sub1")).scope()
+            new StreamConfiguration().subscriptionId("sub1"), null).scope()
     );
+
+    assertEquals(
+        "custom",
+        StreamResourceSupport.buildResourceOptions(client,
+            new StreamConfiguration().eventTypeName("et"), "custom").scope()
+    );
+
+    assertEquals(
+        "custom",
+        StreamResourceSupport.buildResourceOptions(client,
+            new StreamConfiguration().subscriptionId("sub1"), "custom").scope()
+    );
+
   }
 
   @Test


### PR DESCRIPTION
The scopes() method on the StreamProcessor.Builder allows a custom scope
to be passed in. If there's no custom scope, the default for the request
is applied.

For #48.