### PR TITLE
Allow custom scopes to be set for subscriptions.

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/CursorCommitResultCollection.java
+++ b/nakadi-java-client/src/main/java/nakadi/CursorCommitResultCollection.java
@@ -7,15 +7,15 @@ import java.util.List;
  */
 public class CursorCommitResultCollection extends ResourceCollection<CursorCommitResult> {
 
-  private final SubscriptionResource resource;
+  private final SubscriptionResourceReal resource;
 
   /**
    * @param items the results
    * @param links links for pagination
    * @param resource a subscription resource
    */
-  public CursorCommitResultCollection(List<CursorCommitResult> items, List<ResourceLink> links,
-      SubscriptionResource resource) {
+  CursorCommitResultCollection(List<CursorCommitResult> items, List<ResourceLink> links,
+      SubscriptionResourceReal resource) {
     super(items, links);
     this.resource = resource;
   }

--- a/nakadi-java-client/src/main/java/nakadi/Resources.java
+++ b/nakadi-java-client/src/main/java/nakadi/Resources.java
@@ -55,7 +55,7 @@ public class Resources {
    * @return a resource for working with subscriptions
    */
   public SubscriptionResource subscriptions() {
-    return new SubscriptionResource(client);
+    return new SubscriptionResourceReal(client);
   }
 
   /**

--- a/nakadi-java-client/src/main/java/nakadi/SubscriptionCollection.java
+++ b/nakadi-java-client/src/main/java/nakadi/SubscriptionCollection.java
@@ -9,10 +9,10 @@ import java.util.List;
  */
 public class SubscriptionCollection extends ResourceCollection<Subscription> {
 
-  private final SubscriptionResource subscriptionResource;
+  private final SubscriptionResourceReal subscriptionResource;
 
-  public SubscriptionCollection(List<Subscription> items, List<ResourceLink> links,
-      SubscriptionResource subscriptionResource) {
+  SubscriptionCollection(List<Subscription> items, List<ResourceLink> links,
+      SubscriptionResourceReal subscriptionResource) {
     super(items, links);
     this.subscriptionResource = subscriptionResource;
   }

--- a/nakadi-java-client/src/main/java/nakadi/SubscriptionCursorCollection.java
+++ b/nakadi-java-client/src/main/java/nakadi/SubscriptionCursorCollection.java
@@ -9,11 +9,11 @@ import java.util.List;
  */
 public class SubscriptionCursorCollection extends ResourceCollection<Cursor> {
 
-  private final SubscriptionResource subscriptionResource;
+  private final SubscriptionResourceReal subscriptionResource;
 
-  public SubscriptionCursorCollection(List<Cursor> items,
+  SubscriptionCursorCollection(List<Cursor> items,
       List<ResourceLink> links,
-      SubscriptionResource subscriptionResource) {
+      SubscriptionResourceReal subscriptionResource) {
     super(items, links);
     this.subscriptionResource = subscriptionResource;
   }

--- a/nakadi-java-client/src/main/java/nakadi/SubscriptionEventTypeStatsCollection.java
+++ b/nakadi-java-client/src/main/java/nakadi/SubscriptionEventTypeStatsCollection.java
@@ -9,10 +9,10 @@ import java.util.List;
  */
 public class SubscriptionEventTypeStatsCollection
     extends ResourceCollection<SubscriptionEventTypeStats> {
-  private final SubscriptionResource subscriptionResource;
+  private final SubscriptionResourceReal subscriptionResource;
 
-  public SubscriptionEventTypeStatsCollection(List<SubscriptionEventTypeStats> items,
-      List<ResourceLink> links, SubscriptionResource subscriptionResource) {
+  SubscriptionEventTypeStatsCollection(List<SubscriptionEventTypeStats> items,
+      List<ResourceLink> links, SubscriptionResourceReal subscriptionResource) {
     super(items, links);
     this.subscriptionResource = subscriptionResource;
   }

--- a/nakadi-java-client/src/main/java/nakadi/SubscriptionResource.java
+++ b/nakadi-java-client/src/main/java/nakadi/SubscriptionResource.java
@@ -7,6 +7,15 @@ import java.util.Map;
  */
 public interface SubscriptionResource {
 
+  /**
+   * Set the OAuth scope to be used for the request. This can be reset between requests.
+   *
+   * @param scope the OAuth scope to be used for the request
+   * @return this
+   */
+  SubscriptionResource scope(String scope);
+
+
   Response create(Subscription subscription)
       throws AuthorizationException, ClientException, ServerException, InvalidException,
       RateLimitException, NakadiException;

--- a/nakadi-java-client/src/main/java/nakadi/SubscriptionResource.java
+++ b/nakadi-java-client/src/main/java/nakadi/SubscriptionResource.java
@@ -1,266 +1,41 @@
 package nakadi;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.gson.reflect.TypeToken;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 
-public class SubscriptionResource {
-  public static final String PATH_CURSORS = "cursors";
-  public static final String PATH_STATS = "stats";
-  private static final String PATH = "subscriptions";
-  private static final String APPLICATION_JSON = "application/json";
-  private static final Type TYPE_CURSOR_COMMIT_RESULT =
-      new TypeToken<CursorCommitResultCollection>() {
-      }.getType();
-  private static final Type TYPE = new TypeToken<List<Subscription>>() {
-  }.getType();
+/**
+ * Supports API operations related to subscriptions.
+ */
+public interface SubscriptionResource {
 
-  private final NakadiClient client;
-  private CursorCommitResultCollection sentinelCursorCommitResultCollection;
-
-  public SubscriptionResource(NakadiClient client) {
-    this.client = client;
-    this.sentinelCursorCommitResultCollection =
-        new CursorCommitResultCollection(Lists.newArrayList(), Lists.newArrayList(), this);
-  }
-
-  public Response create(Subscription subscription)
+  Response create(Subscription subscription)
       throws AuthorizationException, ClientException, ServerException, InvalidException,
-      RateLimitException, NakadiException {
-    Objects.requireNonNull(subscription);
-    return client.resourceProvider().newResource()
-        .requestThrowing(Resource.POST, collectionUri().buildString(), prepareOptions(),
-            subscription);
-  }
+      RateLimitException, NakadiException;
 
-  public Subscription find(String id)
+  Subscription find(String id)
       throws AuthorizationException, ClientException, ServerException, InvalidException,
-      RateLimitException, NakadiException {
-    Objects.requireNonNull(id);
-    String url = collectionUri().path(id).buildString();
-    return client.resourceProvider().newResource()
-        .requestThrowing(Resource.GET, url, prepareOptions(), Subscription.class);
-  }
+      RateLimitException, NakadiException;
 
-  public SubscriptionCollection list()
+  SubscriptionCollection list()
       throws AuthorizationException, ClientException, ServerException, InvalidException,
-      RateLimitException, NakadiException {
-    return list(new QueryParams());
-  }
+      RateLimitException, NakadiException;
 
-  public SubscriptionCollection list(QueryParams params)
+  SubscriptionCollection list(QueryParams params)
       throws AuthorizationException, ClientException, ServerException, InvalidException,
-      RateLimitException, NakadiException {
-    Objects.requireNonNull(params);
-    return loadPage(collectionUri().query(params).buildString());
-  }
+      RateLimitException, NakadiException;
 
-  public Response delete(String id)
+  Response delete(String id)
       throws AuthorizationException, ClientException, ServerException, InvalidException,
-      RateLimitException, NakadiException {
-    String url = collectionUri().path(id).buildString();
-    return client.resourceProvider().newResource()
-        .requestThrowing(Resource.DELETE, url, prepareOptions());
-  }
+      RateLimitException, NakadiException;
 
-  public CursorCommitResultCollection checkpoint(Map<String, String> context, Cursor... cursors)
+  CursorCommitResultCollection checkpoint(Map<String, String> context, Cursor... cursors)
       throws AuthorizationException, ClientException, ServerException, InvalidException,
-      RateLimitException, ContractException, NakadiException {
-    NakadiException.throwNonNull(cursors, "Please provide cursors");
-    NakadiException.throwNonNull(context, "Please provide a context map");
-    NakadiException.throwNonNull(context.get(StreamResourceSupport.X_NAKADI_STREAM_ID),
-        "Please provide the header " + StreamResourceSupport.X_NAKADI_STREAM_ID);
-    NakadiException.throwNonNull(context.get(StreamResourceSupport.SUBSCRIPTION_ID),
-        "Please provide the subscription id");
+      RateLimitException, ContractException, NakadiException;
 
-    List<Cursor> cursorList = Arrays.asList(cursors);
-
-    Map<String, Object> requestMap = Maps.newHashMap();
-    requestMap.put("items", cursorList);
-
-    String streamId = context.get(StreamResourceSupport.X_NAKADI_STREAM_ID);
-    String subscriptionId = context.get(StreamResourceSupport.SUBSCRIPTION_ID);
-    String url = collectionUri()
-        .path(subscriptionId)
-        .path(SubscriptionResource.PATH_CURSORS)
-        .buildString();
-    ResourceOptions options = prepareOptions();
-    options.header(StreamResourceSupport.X_NAKADI_STREAM_ID, streamId);
-
-    PolicyBackoff backoff = ExponentialBackoff.newBuilder()
-        .initialInterval(900, TimeUnit.MILLISECONDS)
-        .maxAttempts(3)
-        .maxInterval(2000, TimeUnit.MILLISECONDS)
-        .build();
-
-    Response response = client.resourceProvider().newResource()
-        .requestRetryThrowing(Resource.POST, url, options, requestMap, backoff);
-
-    if (response.statusCode() == 204) {
-      return sentinelCursorCommitResultCollection;
-    }
-
-    if (response.statusCode() == 200) {
-      String raw = response.responseBody().asString();
-      return client.jsonSupport()
-          .fromJson(raw, TYPE_CURSOR_COMMIT_RESULT);
-    }
-
-    // success but not expected, throw this to signal
-    throw new ContractException(Problem.contractProblem(
-        "Success committing cursor with unexpected code", "response: " + response));
-  }
-
-  public SubscriptionCursorCollection cursors(String id)
+  SubscriptionCursorCollection cursors(String id)
       throws AuthorizationException, ClientException, ServerException, InvalidException,
-      RateLimitException, NakadiException {
-    Objects.requireNonNull(id);
-    return loadCursorPage(collectionUri().path(id).path(PATH_CURSORS).buildString());
-  }
+      RateLimitException, NakadiException;
 
-  public SubscriptionEventTypeStatsCollection stats(String id)
+  SubscriptionEventTypeStatsCollection stats(String id)
       throws AuthorizationException, ClientException, ServerException, InvalidException,
-      RateLimitException, NakadiException {
-    Objects.requireNonNull(id);
-    return loadStatsPage(collectionUri().path(id).path(PATH_STATS).buildString());
-  }
-
-  SubscriptionEventTypeStatsCollection loadStatsPage(String url) {
-    Response response = client.resourceProvider().newResource()
-        .requestThrowing(Resource.GET, url,
-            ResourceSupport.options(APPLICATION_JSON)
-                .tokenProvider(client.resourceTokenProvider()));
-
-    /*
-    map response to the local collection api; this allows iterators and iterables to be used
-    over the results. the api doesn't page, so pass an empty list for pagination
-     */
-    SubscriptionEventTypeStatsList cursors =
-        client.jsonSupport()
-            .fromJson(response.responseBody().asString(), SubscriptionEventTypeStatsList.class);
-    List<SubscriptionEventTypeStats> items = cursors.items();
-    return new SubscriptionEventTypeStatsCollection(items, Lists.newArrayList(), this);
-  }
-
-  SubscriptionCursorCollection loadCursorPage(String url) {
-    Response response = client.resourceProvider().newResource()
-        .requestThrowing(Resource.GET, url,
-            ResourceSupport.options(APPLICATION_JSON)
-                .tokenProvider(client.resourceTokenProvider()));
-
-    /*
-    map response to the local collection api; this allows iterators and iterables to be used
-    over the results. the api doesn't page, so pass an empty list for pagination
-     */
-    SubscriptionCursorList cursors =
-        client.jsonSupport()
-            .fromJson(response.responseBody().asString(), SubscriptionCursorList.class);
-    List<Cursor> items = cursors.items();
-    return new SubscriptionCursorCollection(items, Lists.newArrayList(), this);
-  }
-
-  SubscriptionCollection loadPage(String url) {
-    Response response = client.resourceProvider().newResource()
-        .requestThrowing(Resource.GET, url,
-            ResourceSupport.options(APPLICATION_JSON)
-                .tokenProvider(client.resourceTokenProvider()));
-
-    /*
-    map server response to the local collection api; the server yaml doesn't define a direct
-    response object just a pair of PaginationLinks and List<Subscription> items, so we
-    define and use a temp SubscriptionList to capture it. We also remap PaginationLinks because
-    they don't capture rels (this is a problem with HAL, the underlying format used for links).
-
-    todo: replace SubscriptionList entirely as we're dropping unexpected rels via PaginationLinks
-     */
-    SubscriptionList list =
-        client.jsonSupport().fromJson(response.responseBody().asString(), SubscriptionList.class);
-    return new SubscriptionCollection(toSubscriptions(list.items()), toLinks(list._links()), this);
-  }
-
-  private List<ResourceLink> toLinks(PaginationLinks _links) {
-    List<ResourceLink> links = Lists.newArrayList();
-    if (_links != null) {
-      final PaginationLink prev = _links.prev();
-      final PaginationLink next = _links.next();
-
-      if (prev != null) {
-        links.add(new ResourceLink("prev", prev.href()));
-      }
-
-      if (next != null) {
-        links.add(new ResourceLink("next", next.href()));
-      }
-    }
-    return links;
-  }
-
-  private List<Subscription> toSubscriptions(List<Subscription> items) {
-    List<Subscription> subscriptions = Lists.newArrayList();
-    if (items != null) {
-      subscriptions.addAll(items);
-    }
-    return subscriptions;
-  }
-
-  private ResourceOptions prepareOptions() {
-    return ResourceSupport.options(APPLICATION_JSON)
-        .tokenProvider(client.resourceTokenProvider());
-  }
-
-  private UriBuilder collectionUri() {
-    return UriBuilder.builder(client.baseURI()).path(PATH);
-  }
-
-  ResourceCollection<CursorCommitResult> loadCursorCommitPage(String url) {
-    return new CursorCommitResultCollection(loadCollection(url), Lists.newArrayList(), this);
-  }
-
-  private List<CursorCommitResult> loadCollection(String url) {
-    Response response = client.resourceProvider().newResource()
-        .requestThrowing(Resource.GET, url,
-            ResourceSupport.options(APPLICATION_JSON)
-                .tokenProvider(client.resourceTokenProvider()));
-
-    return client.jsonSupport().fromJson(response.responseBody().asString(), TYPE);
-  }
-
-  private static class SubscriptionList {
-
-    private final PaginationLinks _links = null;
-    private final List<Subscription> items = new ArrayList<>();
-
-    PaginationLinks _links() {
-      return _links;
-    }
-
-    List<Subscription> items() {
-      return items;
-    }
-  }
-
-  private static class SubscriptionCursorList {
-
-    private final List<Cursor> items = new ArrayList<>();
-
-    List<Cursor> items() {
-      return items;
-    }
-  }
-
-  private static class SubscriptionEventTypeStatsList {
-
-    private final List<SubscriptionEventTypeStats> items = new ArrayList<>();
-
-    List<SubscriptionEventTypeStats> items() {
-      return items;
-    }
-  }
+      RateLimitException, NakadiException;
 }

--- a/nakadi-java-client/src/main/java/nakadi/SubscriptionResourceReal.java
+++ b/nakadi-java-client/src/main/java/nakadi/SubscriptionResourceReal.java
@@ -1,0 +1,269 @@
+package nakadi;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.gson.reflect.TypeToken;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+
+class SubscriptionResourceReal implements SubscriptionResource {
+
+  private static final String PATH_CURSORS = "cursors";
+  private static final String PATH_STATS = "stats";
+  private static final String PATH = "subscriptions";
+  private static final String APPLICATION_JSON = "application/json";
+  private static final Type TYPE_CURSOR_COMMIT_RESULT =
+      new TypeToken<CursorCommitResultCollection>() {
+      }.getType();
+  private static final Type TYPE = new TypeToken<List<Subscription>>() {
+  }.getType();
+
+  private final NakadiClient client;
+  private CursorCommitResultCollection sentinelCursorCommitResultCollection;
+
+  SubscriptionResourceReal(NakadiClient client) {
+    this.client = client;
+    this.sentinelCursorCommitResultCollection =
+        new CursorCommitResultCollection(Lists.newArrayList(), Lists.newArrayList(), this);
+  }
+
+  @Override public Response create(Subscription subscription)
+      throws AuthorizationException, ClientException, ServerException, InvalidException,
+      RateLimitException, NakadiException {
+    Objects.requireNonNull(subscription);
+    return client.resourceProvider().newResource()
+        .requestThrowing(Resource.POST, collectionUri().buildString(), prepareOptions(),
+            subscription);
+  }
+
+  @Override public Subscription find(String id)
+      throws AuthorizationException, ClientException, ServerException, InvalidException,
+      RateLimitException, NakadiException {
+    Objects.requireNonNull(id);
+    String url = collectionUri().path(id).buildString();
+    return client.resourceProvider().newResource()
+        .requestThrowing(Resource.GET, url, prepareOptions(), Subscription.class);
+  }
+
+  @Override public SubscriptionCollection list()
+      throws AuthorizationException, ClientException, ServerException, InvalidException,
+      RateLimitException, NakadiException {
+    return list(new QueryParams());
+  }
+
+  @Override public SubscriptionCollection list(QueryParams params)
+      throws AuthorizationException, ClientException, ServerException, InvalidException,
+      RateLimitException, NakadiException {
+    Objects.requireNonNull(params);
+    return loadPage(collectionUri().query(params).buildString());
+  }
+
+  @Override public Response delete(String id)
+      throws AuthorizationException, ClientException, ServerException, InvalidException,
+      RateLimitException, NakadiException {
+    String url = collectionUri().path(id).buildString();
+    return client.resourceProvider().newResource()
+        .requestThrowing(Resource.DELETE, url, prepareOptions());
+  }
+
+  @Override
+  public CursorCommitResultCollection checkpoint(Map<String, String> context, Cursor... cursors)
+      throws AuthorizationException, ClientException, ServerException, InvalidException,
+      RateLimitException, ContractException, NakadiException {
+    NakadiException.throwNonNull(cursors, "Please provide cursors");
+    NakadiException.throwNonNull(context, "Please provide a context map");
+    NakadiException.throwNonNull(context.get(StreamResourceSupport.X_NAKADI_STREAM_ID),
+        "Please provide the header " + StreamResourceSupport.X_NAKADI_STREAM_ID);
+    NakadiException.throwNonNull(context.get(StreamResourceSupport.SUBSCRIPTION_ID),
+        "Please provide the subscription id");
+
+    List<Cursor> cursorList = Arrays.asList(cursors);
+
+    Map<String, Object> requestMap = Maps.newHashMap();
+    requestMap.put("items", cursorList);
+
+    String streamId = context.get(StreamResourceSupport.X_NAKADI_STREAM_ID);
+    String subscriptionId = context.get(StreamResourceSupport.SUBSCRIPTION_ID);
+    String url = collectionUri()
+        .path(subscriptionId)
+        .path(SubscriptionResourceReal.PATH_CURSORS)
+        .buildString();
+    ResourceOptions options = prepareOptions();
+    options.header(StreamResourceSupport.X_NAKADI_STREAM_ID, streamId);
+
+    PolicyBackoff backoff = ExponentialBackoff.newBuilder()
+        .initialInterval(900, TimeUnit.MILLISECONDS)
+        .maxAttempts(3)
+        .maxInterval(2000, TimeUnit.MILLISECONDS)
+        .build();
+
+    Response response = client.resourceProvider().newResource()
+        .requestRetryThrowing(Resource.POST, url, options, requestMap, backoff);
+
+    if (response.statusCode() == 204) {
+      return sentinelCursorCommitResultCollection;
+    }
+
+    if (response.statusCode() == 200) {
+      String raw = response.responseBody().asString();
+      return client.jsonSupport()
+          .fromJson(raw, TYPE_CURSOR_COMMIT_RESULT);
+    }
+
+    // success but not expected, throw this to signal
+    throw new ContractException(Problem.contractProblem(
+        "Success committing cursor with unexpected code", "response: " + response));
+  }
+
+  @Override public SubscriptionCursorCollection cursors(String id)
+      throws AuthorizationException, ClientException, ServerException, InvalidException,
+      RateLimitException, NakadiException {
+    Objects.requireNonNull(id);
+    return loadCursorPage(collectionUri().path(id).path(PATH_CURSORS).buildString());
+  }
+
+  @Override public SubscriptionEventTypeStatsCollection stats(String id)
+      throws AuthorizationException, ClientException, ServerException, InvalidException,
+      RateLimitException, NakadiException {
+    Objects.requireNonNull(id);
+    return loadStatsPage(collectionUri().path(id).path(PATH_STATS).buildString());
+  }
+
+  SubscriptionEventTypeStatsCollection loadStatsPage(String url) {
+    Response response = client.resourceProvider().newResource()
+        .requestThrowing(Resource.GET, url,
+            ResourceSupport.options(APPLICATION_JSON)
+                .tokenProvider(client.resourceTokenProvider()));
+
+    /*
+    map response to the local collection api; this allows iterators and iterables to be used
+    over the results. the api doesn't page, so pass an empty list for pagination
+     */
+    SubscriptionEventTypeStatsList cursors =
+        client.jsonSupport()
+            .fromJson(response.responseBody().asString(), SubscriptionEventTypeStatsList.class);
+    List<SubscriptionEventTypeStats> items = cursors.items();
+    return new SubscriptionEventTypeStatsCollection(items, Lists.newArrayList(), this);
+  }
+
+  SubscriptionCursorCollection loadCursorPage(String url) {
+    Response response = client.resourceProvider().newResource()
+        .requestThrowing(Resource.GET, url,
+            ResourceSupport.options(APPLICATION_JSON)
+                .tokenProvider(client.resourceTokenProvider()));
+
+    /*
+    map response to the local collection api; this allows iterators and iterables to be used
+    over the results. the api doesn't page, so pass an empty list for pagination
+     */
+    SubscriptionCursorList cursors =
+        client.jsonSupport()
+            .fromJson(response.responseBody().asString(), SubscriptionCursorList.class);
+    List<Cursor> items = cursors.items();
+    return new SubscriptionCursorCollection(items, Lists.newArrayList(), this);
+  }
+
+  SubscriptionCollection loadPage(String url) {
+    Response response = client.resourceProvider().newResource()
+        .requestThrowing(Resource.GET, url,
+            ResourceSupport.options(APPLICATION_JSON)
+                .tokenProvider(client.resourceTokenProvider()));
+
+    /*
+    map server response to the local collection api; the server yaml doesn't define a direct
+    response object just a pair of PaginationLinks and List<Subscription> items, so we
+    define and use a temp SubscriptionList to capture it. We also remap PaginationLinks because
+    they don't capture rels (this is a problem with HAL, the underlying format used for links).
+
+    todo: replace SubscriptionList entirely as we're dropping unexpected rels via PaginationLinks
+     */
+    SubscriptionList list =
+        client.jsonSupport().fromJson(response.responseBody().asString(), SubscriptionList.class);
+    return new SubscriptionCollection(toSubscriptions(list.items()), toLinks(list._links()), this);
+  }
+
+  private List<ResourceLink> toLinks(PaginationLinks _links) {
+    List<ResourceLink> links = Lists.newArrayList();
+    if (_links != null) {
+      final PaginationLink prev = _links.prev();
+      final PaginationLink next = _links.next();
+
+      if (prev != null) {
+        links.add(new ResourceLink("prev", prev.href()));
+      }
+
+      if (next != null) {
+        links.add(new ResourceLink("next", next.href()));
+      }
+    }
+    return links;
+  }
+
+  private List<Subscription> toSubscriptions(List<Subscription> items) {
+    List<Subscription> subscriptions = Lists.newArrayList();
+    if (items != null) {
+      subscriptions.addAll(items);
+    }
+    return subscriptions;
+  }
+
+  private ResourceOptions prepareOptions() {
+    return ResourceSupport.options(APPLICATION_JSON)
+        .tokenProvider(client.resourceTokenProvider());
+  }
+
+  private UriBuilder collectionUri() {
+    return UriBuilder.builder(client.baseURI()).path(PATH);
+  }
+
+  ResourceCollection<CursorCommitResult> loadCursorCommitPage(String url) {
+    return new CursorCommitResultCollection(loadCollection(url), Lists.newArrayList(), this);
+  }
+
+  private List<CursorCommitResult> loadCollection(String url) {
+    Response response = client.resourceProvider().newResource()
+        .requestThrowing(Resource.GET, url,
+            ResourceSupport.options(APPLICATION_JSON)
+                .tokenProvider(client.resourceTokenProvider()));
+
+    return client.jsonSupport().fromJson(response.responseBody().asString(), TYPE);
+  }
+
+  private static class SubscriptionList {
+
+    private final PaginationLinks _links = null;
+    private final List<Subscription> items = new ArrayList<>();
+
+    PaginationLinks _links() {
+      return _links;
+    }
+
+    List<Subscription> items() {
+      return items;
+    }
+  }
+
+  private static class SubscriptionCursorList {
+
+    private final List<Cursor> items = new ArrayList<>();
+
+    List<Cursor> items() {
+      return items;
+    }
+  }
+
+  private static class SubscriptionEventTypeStatsList {
+
+    private final List<SubscriptionEventTypeStats> items = new ArrayList<>();
+
+    List<SubscriptionEventTypeStats> items() {
+      return items;
+    }
+  }
+}

--- a/nakadi-java-client/src/test/java/nakadi/SubscriptionResourceRealTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/SubscriptionResourceRealTest.java
@@ -1,0 +1,644 @@
+package nakadi;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import okhttp3.OkHttpClient;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Matchers;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SubscriptionResourceRealTest {
+
+  @Test
+  public void listWithScope() {
+    final boolean[] askedForDefaultToken = {false};
+    final boolean[] askedForCustomToken = {false};
+    String customScope = "custom";
+
+    NakadiClient client =
+        spy(NakadiClient.newBuilder()
+            .baseURI("http://localhost:9080")
+            .tokenProvider(scope -> {
+              if (TokenProvider.NAKADI_EVENT_STREAM_READ.equals(scope)) {
+                askedForDefaultToken[0] = true;
+              }
+
+              if (customScope.equals(scope)) {
+                askedForCustomToken[0] = true;
+              }
+
+              return Optional.empty();
+            })
+            .build());
+
+    Resource r0 = spy(new OkHttpResource(
+        new OkHttpClient.Builder().build(),
+        new GsonSupport(),
+        mock(MetricCollector.class)));
+
+    when(client.resourceProvider()).thenReturn(mock(ResourceProvider.class));
+    when(client.resourceProvider().newResource()).thenReturn(r0);
+
+    try {
+      new SubscriptionResourceReal(client)
+          .list();
+    } catch (NetworkException | NotFoundException ignored) {
+    }
+
+    ArgumentCaptor<ResourceOptions> options = ArgumentCaptor.forClass(ResourceOptions.class);
+
+    verify(r0, times(1)).requestThrowing(
+        Matchers.eq(Resource.GET),
+        Matchers.eq("http://localhost:9080/subscriptions"),
+        options.capture()
+    );
+
+    assertEquals(TokenProvider.NAKADI_EVENT_STREAM_READ, options.getValue().scope());
+    assertTrue(askedForDefaultToken[0]);
+    assertFalse(askedForCustomToken[0]);
+
+    Resource r1 = spy(new OkHttpResource(
+        new OkHttpClient.Builder().build(),
+        new GsonSupport(),
+        mock(MetricCollector.class)));
+
+    when(client.resourceProvider()).thenReturn(mock(ResourceProvider.class));
+    when(client.resourceProvider().newResource()).thenReturn(r1);
+
+    try {
+      askedForDefaultToken[0] = false;
+      askedForCustomToken[0] = false;
+      assertFalse(askedForDefaultToken[0]);
+      assertFalse(askedForCustomToken[0]);
+
+      new SubscriptionResourceReal(client)
+          .scope(customScope)
+          .list();
+    } catch (NetworkException | NotFoundException ignored) {
+    }
+
+    options = ArgumentCaptor.forClass(ResourceOptions.class);
+
+    verify(r1, times(1)).requestThrowing(
+        Matchers.eq(Resource.GET),
+        Matchers.eq("http://localhost:9080/subscriptions"),
+        options.capture()
+    );
+
+    assertEquals(customScope, options.getValue().scope());
+    assertFalse(askedForDefaultToken[0]);
+    assertTrue(askedForCustomToken[0]);
+
+
+  }
+
+  @Test
+  public void findWithScope() {
+    final boolean[] askedForDefaultToken = {false};
+    final boolean[] askedForCustomToken = {false};
+    String customScope = "custom";
+
+    NakadiClient client =
+        spy(NakadiClient.newBuilder()
+            .baseURI("http://localhost:9080")
+            .tokenProvider(scope -> {
+              if (TokenProvider.NAKADI_EVENT_STREAM_READ.equals(scope)) {
+                askedForDefaultToken[0] = true;
+              }
+
+              if (customScope.equals(scope)) {
+                askedForCustomToken[0] = true;
+              }
+
+              return Optional.empty();
+            })
+            .build());
+
+    Resource r0 = spy(new OkHttpResource(
+        new OkHttpClient.Builder().build(),
+        new GsonSupport(),
+        mock(MetricCollector.class)));
+
+    when(client.resourceProvider()).thenReturn(mock(ResourceProvider.class));
+    when(client.resourceProvider().newResource()).thenReturn(r0);
+
+    try {
+      new SubscriptionResourceReal(client)
+          .find("sid");
+    } catch (NetworkException | NotFoundException ignored) {
+    }
+
+    ArgumentCaptor<ResourceOptions> options = ArgumentCaptor.forClass(ResourceOptions.class);
+
+    verify(r0, times(1)).requestThrowing(
+        Matchers.eq(Resource.GET),
+        Matchers.eq("http://localhost:9080/subscriptions/sid"),
+        options.capture(),
+        Matchers.eq(Subscription.class)
+    );
+
+    assertEquals(TokenProvider.NAKADI_EVENT_STREAM_READ, options.getValue().scope());
+    assertTrue(askedForDefaultToken[0]);
+    assertFalse(askedForCustomToken[0]);
+
+    Resource r1 = spy(new OkHttpResource(
+        new OkHttpClient.Builder().build(),
+        new GsonSupport(),
+        mock(MetricCollector.class)));
+
+    when(client.resourceProvider()).thenReturn(mock(ResourceProvider.class));
+    when(client.resourceProvider().newResource()).thenReturn(r1);
+
+    try {
+      askedForDefaultToken[0] = false;
+      askedForCustomToken[0] = false;
+      assertFalse(askedForDefaultToken[0]);
+      assertFalse(askedForCustomToken[0]);
+
+      new SubscriptionResourceReal(client)
+          .scope(customScope)
+          .find("sid");
+    } catch (NetworkException | NotFoundException ignored) {
+    }
+
+    options = ArgumentCaptor.forClass(ResourceOptions.class);
+
+    verify(r1, times(1)).requestThrowing(
+        Matchers.eq(Resource.GET),
+        Matchers.eq("http://localhost:9080/subscriptions/sid"),
+        options.capture(),
+        Matchers.eq(Subscription.class)
+    );
+
+    assertEquals(customScope, options.getValue().scope());
+    assertFalse(askedForDefaultToken[0]);
+    assertTrue(askedForCustomToken[0]);
+
+
+  }
+
+  @Test
+  public void cursorsWithScope() {
+    final boolean[] askedForDefaultToken = {false};
+    final boolean[] askedForCustomToken = {false};
+    String customScope = "custom";
+
+    NakadiClient client =
+        spy(NakadiClient.newBuilder()
+            .baseURI("http://localhost:9080")
+            .tokenProvider(scope -> {
+              if (TokenProvider.NAKADI_EVENT_STREAM_READ.equals(scope)) {
+                askedForDefaultToken[0] = true;
+              }
+
+              if (customScope.equals(scope)) {
+                askedForCustomToken[0] = true;
+              }
+
+              return Optional.empty();
+            })
+            .build());
+
+    Resource r0 = spy(new OkHttpResource(
+        new OkHttpClient.Builder().build(),
+        new GsonSupport(),
+        mock(MetricCollector.class)));
+
+    when(client.resourceProvider()).thenReturn(mock(ResourceProvider.class));
+    when(client.resourceProvider().newResource()).thenReturn(r0);
+
+    try {
+      new SubscriptionResourceReal(client)
+          .cursors("sid");
+    } catch (NetworkException | NotFoundException ignored) {
+    }
+
+    ArgumentCaptor<ResourceOptions> options = ArgumentCaptor.forClass(ResourceOptions.class);
+
+    verify(r0, times(1)).requestThrowing(
+        Matchers.eq(Resource.GET),
+        Matchers.eq("http://localhost:9080/subscriptions/sid/cursors"),
+        options.capture()
+    );
+
+    assertEquals(TokenProvider.NAKADI_EVENT_STREAM_READ, options.getValue().scope());
+    assertTrue(askedForDefaultToken[0]);
+    assertFalse(askedForCustomToken[0]);
+
+    Resource r1 = spy(new OkHttpResource(
+        new OkHttpClient.Builder().build(),
+        new GsonSupport(),
+        mock(MetricCollector.class)));
+
+    when(client.resourceProvider()).thenReturn(mock(ResourceProvider.class));
+    when(client.resourceProvider().newResource()).thenReturn(r1);
+
+    try {
+      askedForDefaultToken[0] = false;
+      askedForCustomToken[0] = false;
+      assertFalse(askedForDefaultToken[0]);
+      assertFalse(askedForCustomToken[0]);
+
+      new SubscriptionResourceReal(client)
+          .scope(customScope)
+          .cursors("sid");
+    } catch (NetworkException | NotFoundException ignored) {
+    }
+
+    options = ArgumentCaptor.forClass(ResourceOptions.class);
+
+    verify(r1, times(1)).requestThrowing(
+        Matchers.eq(Resource.GET),
+        Matchers.eq("http://localhost:9080/subscriptions/sid/cursors"),
+        options.capture()
+    );
+
+    assertEquals(customScope, options.getValue().scope());
+    assertFalse(askedForDefaultToken[0]);
+    assertTrue(askedForCustomToken[0]);
+
+
+  }
+
+  @Test
+  public void statsWithScope() {
+    final boolean[] askedForDefaultToken = {false};
+    final boolean[] askedForCustomToken = {false};
+    String customScope = "custom";
+
+    NakadiClient client =
+        spy(NakadiClient.newBuilder()
+            .baseURI("http://localhost:9080")
+            .tokenProvider(scope -> {
+              if (TokenProvider.NAKADI_EVENT_STREAM_READ.equals(scope)) {
+                askedForDefaultToken[0] = true;
+              }
+
+              if (customScope.equals(scope)) {
+                askedForCustomToken[0] = true;
+              }
+
+              return Optional.empty();
+            })
+            .build());
+
+    Resource r0 = spy(new OkHttpResource(
+        new OkHttpClient.Builder().build(),
+        new GsonSupport(),
+        mock(MetricCollector.class)));
+
+    when(client.resourceProvider()).thenReturn(mock(ResourceProvider.class));
+    when(client.resourceProvider().newResource()).thenReturn(r0);
+
+    try {
+      new SubscriptionResourceReal(client)
+          .stats("sid");
+    } catch (NetworkException | NotFoundException ignored) {
+    }
+
+    ArgumentCaptor<ResourceOptions> options = ArgumentCaptor.forClass(ResourceOptions.class);
+
+    verify(r0, times(1)).requestThrowing(
+        Matchers.eq(Resource.GET),
+        Matchers.eq("http://localhost:9080/subscriptions/sid/stats"),
+        options.capture()
+    );
+
+    assertEquals(TokenProvider.NAKADI_EVENT_STREAM_READ, options.getValue().scope());
+    assertTrue(askedForDefaultToken[0]);
+    assertFalse(askedForCustomToken[0]);
+
+    Resource r1 = spy(new OkHttpResource(
+        new OkHttpClient.Builder().build(),
+        new GsonSupport(),
+        mock(MetricCollector.class)));
+
+    when(client.resourceProvider()).thenReturn(mock(ResourceProvider.class));
+    when(client.resourceProvider().newResource()).thenReturn(r1);
+
+    try {
+      askedForDefaultToken[0] = false;
+      askedForCustomToken[0] = false;
+      assertFalse(askedForDefaultToken[0]);
+      assertFalse(askedForCustomToken[0]);
+
+      new SubscriptionResourceReal(client)
+          .scope(customScope)
+          .stats("sid");
+    } catch (NetworkException | NotFoundException ignored) {
+    }
+
+    options = ArgumentCaptor.forClass(ResourceOptions.class);
+
+    verify(r1, times(1)).requestThrowing(
+        Matchers.eq(Resource.GET),
+        Matchers.eq("http://localhost:9080/subscriptions/sid/stats"),
+        options.capture()
+    );
+
+    assertEquals(customScope, options.getValue().scope());
+    assertFalse(askedForDefaultToken[0]);
+    assertTrue(askedForCustomToken[0]);
+
+
+  }
+
+  @Test
+  public void deleteWithScope() {
+    final boolean[] askedForDefaultToken = {false};
+    final boolean[] askedForCustomToken = {false};
+    String customScope = "custom";
+
+    NakadiClient client =
+        spy(NakadiClient.newBuilder()
+            .baseURI("http://localhost:9080")
+            .tokenProvider(scope -> {
+              if (TokenProvider.NAKADI_CONFIG_WRITE.equals(scope)) {
+                askedForDefaultToken[0] = true;
+              }
+
+              if (customScope.equals(scope)) {
+                askedForCustomToken[0] = true;
+              }
+
+              return Optional.empty();
+            })
+            .build());
+
+    Resource r0 = spy(new OkHttpResource(
+        new OkHttpClient.Builder().build(),
+        new GsonSupport(),
+        mock(MetricCollector.class)));
+
+    when(client.resourceProvider()).thenReturn(mock(ResourceProvider.class));
+    when(client.resourceProvider().newResource()).thenReturn(r0);
+
+    try {
+      new SubscriptionResourceReal(client)
+          .delete("id");
+    } catch (NetworkException | NotFoundException ignored) {
+    }
+
+    ArgumentCaptor<ResourceOptions> options = ArgumentCaptor.forClass(ResourceOptions.class);
+
+    verify(r0, times(1)).requestThrowing(
+        Matchers.eq(Resource.DELETE),
+        Matchers.eq("http://localhost:9080/subscriptions/id"),
+        options.capture()
+    );
+
+    assertEquals(TokenProvider.NAKADI_CONFIG_WRITE, options.getValue().scope());
+    assertTrue(askedForDefaultToken[0]);
+    assertFalse(askedForCustomToken[0]);
+
+    Resource r1 = spy(new OkHttpResource(
+        new OkHttpClient.Builder().build(),
+        new GsonSupport(),
+        mock(MetricCollector.class)));
+
+    when(client.resourceProvider()).thenReturn(mock(ResourceProvider.class));
+    when(client.resourceProvider().newResource()).thenReturn(r1);
+
+    try {
+      askedForDefaultToken[0] = false;
+      askedForCustomToken[0] = false;
+      assertFalse(askedForDefaultToken[0]);
+      assertFalse(askedForCustomToken[0]);
+
+      new SubscriptionResourceReal(client)
+          .scope(customScope)
+          .delete("id");
+    } catch (NetworkException | NotFoundException ignored) {
+    }
+
+    options = ArgumentCaptor.forClass(ResourceOptions.class);
+
+    verify(r1, times(1)).requestThrowing(
+        Matchers.eq(Resource.DELETE),
+        Matchers.eq("http://localhost:9080/subscriptions/id"),
+        options.capture()
+    );
+
+    assertEquals(customScope, options.getValue().scope());
+    assertFalse(askedForDefaultToken[0]);
+    assertTrue(askedForCustomToken[0]);
+
+
+  }
+
+  @Test
+  public void checkpointWithScope() {
+    final boolean[] askedForDefaultToken = {false};
+    final boolean[] askedForCustomToken = {false};
+    String customScope = "custom";
+
+    NakadiClient client =
+        spy(NakadiClient.newBuilder()
+            .baseURI("http://localhost:9080")
+            .tokenProvider(scope -> {
+              if (TokenProvider.NAKADI_EVENT_STREAM_READ.equals(scope)) {
+                askedForDefaultToken[0] = true;
+              }
+
+              if (customScope.equals(scope)) {
+                askedForCustomToken[0] = true;
+              }
+
+              return Optional.empty();
+            })
+            .build());
+
+    Resource r0 = spy(new OkHttpResource(
+        new OkHttpClient.Builder().build(),
+        new GsonSupport(),
+        mock(MetricCollector.class)));
+
+    when(client.resourceProvider()).thenReturn(mock(ResourceProvider.class));
+    when(client.resourceProvider().newResource()).thenReturn(r0);
+
+    Cursor c = new Cursor().cursorToken("ctoken").eventType("et1").offset("0").partition("1");
+
+    Map<String, Object> requestMap = Maps.newHashMap();
+    requestMap.put("items", Lists.newArrayList(c));
+
+    HashMap<String, String> context = Maps.newHashMap();
+    context.put("X-Nakadi-StreamId", "aa");
+    context.put("SubscriptionId", "woo");
+
+    try {
+
+      PolicyBackoff backoff = ExponentialBackoff.newBuilder()
+          .initialInterval(1, TimeUnit.MILLISECONDS)
+          .maxAttempts(1)
+          .maxInterval(1, TimeUnit.MILLISECONDS)
+          .build();
+
+      new SubscriptionResourceReal(client)
+          .checkpoint(backoff, context, c);
+    } catch (NetworkException | NotFoundException ignored) {
+    }
+
+    ArgumentCaptor<ResourceOptions> options = ArgumentCaptor.forClass(ResourceOptions.class);
+
+    verify(r0, times(1)).requestThrowing(
+        Matchers.eq(Resource.POST),
+        Matchers.eq("http://localhost:9080/subscriptions/woo/cursors"),
+        options.capture(),
+        Matchers.eq(requestMap)
+    );
+
+    assertEquals(TokenProvider.NAKADI_EVENT_STREAM_READ, options.getValue().scope());
+    assertTrue(askedForDefaultToken[0]);
+    assertFalse(askedForCustomToken[0]);
+
+    Resource r1 = spy(new OkHttpResource(
+        new OkHttpClient.Builder().build(),
+        new GsonSupport(),
+        mock(MetricCollector.class)));
+
+    when(client.resourceProvider()).thenReturn(mock(ResourceProvider.class));
+    when(client.resourceProvider().newResource()).thenReturn(r1);
+
+    try {
+      askedForDefaultToken[0] = false;
+      askedForCustomToken[0] = false;
+      assertFalse(askedForDefaultToken[0]);
+      assertFalse(askedForCustomToken[0]);
+
+      PolicyBackoff backoff = ExponentialBackoff.newBuilder()
+          .initialInterval(1, TimeUnit.MILLISECONDS)
+          .maxAttempts(1)
+          .maxInterval(1, TimeUnit.MILLISECONDS)
+          .build();
+
+      SubscriptionResource resource = new SubscriptionResourceReal(client).scope(customScope);
+
+      // call the inner method to control the backoff, the interface method's just a wrapper
+      ((SubscriptionResourceReal)resource).checkpoint(backoff, context, c);
+
+    } catch (NetworkException | NotFoundException ignored) {
+    }
+
+    options = ArgumentCaptor.forClass(ResourceOptions.class);
+
+    verify(r1, times(1)).requestThrowing(
+        Matchers.eq(Resource.POST),
+        Matchers.eq("http://localhost:9080/subscriptions/woo/cursors"),
+        options.capture(),
+        Matchers.eq(requestMap)
+    );
+
+    assertEquals(customScope, options.getValue().scope());
+    assertFalse(askedForDefaultToken[0]);
+    assertTrue(askedForCustomToken[0]);
+
+
+  }
+
+  @Test
+  public void createWithScope() {
+    final boolean[] askedForDefaultToken = {false};
+    final boolean[] askedForCustomToken = {false};
+    String customScope = "custom";
+
+    Subscription subscription = new Subscription()
+        .consumerGroup("mccaffrey-cg")
+        .eventType("priority-requisitions")
+        .owningApplication("shaper");
+
+    NakadiClient client =
+        spy(NakadiClient.newBuilder()
+            .baseURI("http://localhost:9080")
+            .tokenProvider(scope -> {
+              if (TokenProvider.NAKADI_EVENT_STREAM_READ.equals(scope)) {
+                askedForDefaultToken[0] = true;
+              }
+
+              if (customScope.equals(scope)) {
+                askedForCustomToken[0] = true;
+              }
+
+              return Optional.empty();
+            })
+            .build());
+
+    Resource r0 = spy(new OkHttpResource(
+        new OkHttpClient.Builder().build(),
+        new GsonSupport(),
+        mock(MetricCollector.class)));
+
+    when(client.resourceProvider()).thenReturn(mock(ResourceProvider.class));
+    when(client.resourceProvider().newResource()).thenReturn(r0);
+
+
+    try {
+
+      new SubscriptionResourceReal(client)
+          .create(subscription);
+    } catch (NetworkException | NotFoundException ignored) {
+    }
+
+    ArgumentCaptor<ResourceOptions> options = ArgumentCaptor.forClass(ResourceOptions.class);
+
+    verify(r0, times(1)).requestThrowing(
+        Matchers.eq(Resource.POST),
+        Matchers.eq("http://localhost:9080/subscriptions"),
+        options.capture(),
+        Matchers.eq(subscription)
+    );
+
+    assertEquals(TokenProvider.NAKADI_EVENT_STREAM_READ, options.getValue().scope());
+    assertTrue(askedForDefaultToken[0]);
+    assertFalse(askedForCustomToken[0]);
+
+    Resource r1 = spy(new OkHttpResource(
+        new OkHttpClient.Builder().build(),
+        new GsonSupport(),
+        mock(MetricCollector.class)));
+
+    when(client.resourceProvider()).thenReturn(mock(ResourceProvider.class));
+    when(client.resourceProvider().newResource()).thenReturn(r1);
+
+    try {
+      askedForDefaultToken[0] = false;
+      askedForCustomToken[0] = false;
+      assertFalse(askedForDefaultToken[0]);
+      assertFalse(askedForCustomToken[0]);
+
+
+      new SubscriptionResourceReal(client)
+          .scope(customScope)
+          .create(subscription);
+
+    } catch (NetworkException | NotFoundException ignored) {
+    }
+
+    options = ArgumentCaptor.forClass(ResourceOptions.class);
+
+    verify(r1, times(1)).requestThrowing(
+        Matchers.eq(Resource.POST),
+        Matchers.eq("http://localhost:9080/subscriptions"),
+        options.capture(),
+        Matchers.eq(subscription)
+    );
+
+    assertEquals(customScope, options.getValue().scope());
+    assertFalse(askedForDefaultToken[0]);
+    assertTrue(askedForCustomToken[0]);
+
+
+  }
+
+}


### PR DESCRIPTION
This uses the default scopes where documented, and a best guess where not 
documented for event type scopes. The scopes() method on the 
SubscriptionResource allows a custom scope to be passed in and can be changed 
per request invocation. If there's no custom scope, the default for the request 
is applied.

For #48.