### PR TITLE
Support backoffs on http requests.

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/Resource.java
+++ b/nakadi-java-client/src/main/java/nakadi/Resource.java
@@ -23,6 +23,8 @@ public interface Resource {
    */
   Resource readTimeout(long timeout, TimeUnit unit);
 
+  Resource policyBackoff(PolicyBackoff policyBackoff);
+
   // todo: reduce these methods and figure out when to throw exceptions
 
   /**
@@ -98,32 +100,6 @@ public interface Resource {
       RateLimitException, NakadiException;
 
   /**
-   * Make a request against the server with a request entity and a backoff retry policy.
-   * Useful for post requests. Exceptions are thrown for HTTP level errors (4xx and 5xx).
-   *
-   * The serialization assumes the output is JSON for now which is ok for the current API.
-   *
-   * @param method the http method
-   * @param url the resource url
-   * @param options requestThrowing options such as headers, and tokens.
-   * @param body the object to create a JSON requestThrowing body from
-   * @param backoff a backoff policy
-   * @param <Req> the body type
-   * @return a http response
-   * @throws AuthorizationException for 401 and 403
-   * @throws ClientException for general 4xx errors
-   * @throws ServerException for general 5xx errors
-   * @throws InvalidException for 422
-   * @throws RateLimitException for 429
-   * @throws NakadiException a non HTTP based exception
-   */
-  <Req> Response requestRetryThrowing(String method, String url, ResourceOptions options, Req body,
-      PolicyBackoff backoff)
-      throws AuthorizationException, ClientException, ServerException, InvalidException,
-      RateLimitException, NakadiException;
-
-
-  /**
    * Make a request against the server with an expected response entity. Useful for get
    * requests. Exceptions are thrown for HTTP level errors (4xx and 5xx).
    *
@@ -145,52 +121,4 @@ public interface Resource {
       throws AuthorizationException, ClientException, ServerException, InvalidException,
       RateLimitException, NakadiException;
 
-  /**
-   * Make a request against the server with an expected response entity and a backoff retry policy.
-   * Useful for get requests. Exceptions are thrown for HTTP level errors (4xx and 5xx).
-   *
-   * The marshalling assumes the response body is JSON for now which is ok for the current API.
-   *
-   * @param method the http method
-   * @param url the resource url
-   * @param options requestThrowing options such as headers, and tokens.
-   * @param res the class to marshal the response body.
-   * @param backoff  a backoff policy
-   * @param <Res> the response type
-   * @return a instance of the response class supplied
-   * @throws AuthorizationException for 401 and 403
-   * @throws ClientException for general 4xx errors
-   * @throws ServerException for general 5xx errors
-   * @throws InvalidException for 422
-   * @throws RateLimitException for 429
-   * @throws NakadiException a non HTTP based exception
-   */
-  <Res> Res requestRetryThrowing(String method, String url, ResourceOptions options, Class<Res> res,
-      PolicyBackoff backoff)
-      throws AuthorizationException, ClientException, ServerException, InvalidException,
-      RateLimitException, NakadiException;
-
-  /**
-   * Make a request against the server with a request entity and an expected response entity.
-   * Exceptions are thrown for HTTP level errors (4xx and 5xx).
-   *
-   * The marshalling assumes the response body is JSON for now which is ok for the current API.
-   *
-   * @param method the http method
-   * @param url the resource url
-   * @param options requestThrowing options such as headers, and tokens.
-   * @param body the object to create a JSON requestThrowing body from
-   * @param res the class to marshal the response body.
-   * @return a instance of the response class supplied
-   * @throws AuthorizationException for 401 and 403
-   * @throws ClientException for general 4xx errors
-   * @throws ServerException for general 5xx errors
-   * @throws InvalidException for 422
-   * @throws RateLimitException for 429
-   * @throws NakadiException a non HTTP based exception
-   */
-  <Res, Req> Res requestThrowing(String method, String url, ResourceOptions options, Req body,
-      Class<Res> res)
-      throws AuthorizationException, ClientException, ServerException, InvalidException,
-      RateLimitException, NakadiException;
 }

--- a/nakadi-java-client/src/main/java/nakadi/StreamConnectionRetry.java
+++ b/nakadi-java-client/src/main/java/nakadi/StreamConnectionRetry.java
@@ -145,7 +145,7 @@ class StreamConnectionRetry {
 
                   logger.info(
                       String.format(
-                          "StreamConnectionRetry: will sleep for a bit, sleep=%s attempt=%d/%d error=%s",
+                          "connection_retry: will sleep for a bit, sleep=%s attempt=%d/%d error=%s",
                           delay, attemptCount,
                           backoff.maxAttempts(), throwable.getMessage()));
                   return Observable.timer(delay, TimeUnit.MILLISECONDS, Schedulers.computation()); // returns 0L


### PR DESCRIPTION
This allows the resource to have a backoff policy object set that will
be applied on the request method. If no backoff is set, the request
is called directly.

For #27.