### PR TITLE
Add tests for status code to exception mappings

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/OkHttpResource.java
+++ b/nakadi-java-client/src/main/java/nakadi/OkHttpResource.java
@@ -87,7 +87,7 @@ class OkHttpResource implements Resource {
       throws NakadiException {
 
     if (retryPolicy == null) {
-      return executeRequest(prepareBuilder(method, url, options, null));
+      return throwIfError(executeRequest(prepareBuilder(method, url, options, null)));
     } else {
       Observable<Response> observable = Observable.defer(
           () -> Observable.just(
@@ -166,7 +166,7 @@ class OkHttpResource implements Resource {
   private Observable.Transformer<Response, Response> buildRetry(RetryPolicy backoff) {
     return new StreamConnectionRetry()
         .retryWhenWithBackoff(
-            backoff, Schedulers.computation(), StreamExceptionSupport::isRetryable);
+            backoff, Schedulers.computation(), ExceptionSupport::isEventStreamRetryable);
   }
 
   private okhttp3.Response okHttpCall(Request.Builder builder) throws IOException {

--- a/nakadi-java-client/src/main/java/nakadi/StreamProcessor.java
+++ b/nakadi-java-client/src/main/java/nakadi/StreamProcessor.java
@@ -250,9 +250,9 @@ public class StreamProcessor implements StreamProcessorManaged {
   private Func1<Throwable, Boolean> buildRetryFunction(StreamConfiguration sc) {
     final Func1<Throwable, Boolean> isRetryable;
     if (sc.isSubscriptionStream()) {
-      isRetryable = StreamExceptionSupport::isSubscriptionRetryable;
+      isRetryable = ExceptionSupport::isSubscriptionStreamRetryable;
     } else {
-      isRetryable = StreamExceptionSupport::isRetryable;
+      isRetryable = ExceptionSupport::isEventStreamRetryable;
     }
     return isRetryable;
   }


### PR DESCRIPTION
Fix a bug in one of OkHttpResource's throwable calls and add tests to cover it.