### PR TITLE
Reject retry delays that are less than 1s.

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/StreamConfiguration.java
+++ b/nakadi-java-client/src/main/java/nakadi/StreamConfiguration.java
@@ -34,6 +34,7 @@ public class StreamConfiguration {
   private long connectTimeout = 30_000L;
   private long readTimeout = 60_000L;
   private long maxRetryDelay = StreamConnectionRetry.DEFAULT_MAX_DELAY_SECONDS;
+  private long minRetryDelay = StreamConnectionRetry.DEFAULT_MIN_DELAY_SECONDS;
   private int maxRetryAttempts = StreamConnectionRetry.DEFAULT_MAX_ATTEMPTS;
 
   public String eventTypeName() {
@@ -204,10 +205,22 @@ public class StreamConfiguration {
     return maxRetryDelay;
   }
 
-  public StreamConfiguration maxRetryDelay(long maxRetryDelay, TimeUnit unit) {
+  /**
+   * Set the maximum time to wait.
+   *
+   * @param maxRetryDelay the maximum time to wait
+   * @param unit the time unit
+   * @return this
+   * @throws IllegalArgumentException if the supplied unit is null or the time is less than
+   * the minimum allowed delay time of 1s
+   */
+  public StreamConfiguration maxRetryDelay(long maxRetryDelay, TimeUnit unit) throws IllegalArgumentException {
     NakadiException.throwNonNull(unit, "Please provide a time unit for max retry delay");
+    if(TimeUnit.SECONDS.toMillis(minRetryDelay) > unit.toMillis(maxRetryDelay)) {
+      throw new IllegalArgumentException("supplied max delay cannot be less than "+minRetryDelay+"s");
+    }
+
     this.maxRetryDelay = unit.toSeconds(maxRetryDelay);
-    ;
     return this;
   }
 

--- a/nakadi-java-client/src/main/java/nakadi/StreamConnectionRetry.java
+++ b/nakadi-java-client/src/main/java/nakadi/StreamConnectionRetry.java
@@ -21,6 +21,7 @@ class StreamConnectionRetry {
 
   static int DEFAULT_INITIAL_DELAY_SECONDS = 1;
   static int DEFAULT_MAX_DELAY_SECONDS = 8;
+  static int DEFAULT_MIN_DELAY_SECONDS = 1;
   static int DEFAULT_MAX_ATTEMPTS = Integer.MAX_VALUE;
   static TimeUnit DEFAULT_TIME_UNIT = TimeUnit.SECONDS;
   private int attemptCount;

--- a/nakadi-java-client/src/test/java/nakadi/StreamConfigurationTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/StreamConfigurationTest.java
@@ -1,14 +1,33 @@
 package nakadi;
 
+import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class StreamConfigurationTest {
 
   private final NakadiClient client =
       NakadiClient.newBuilder().baseURI("http://localhost:9080").build();
+
+  @Test
+  public void maxRetryDelay() {
+    StreamConfiguration et = new StreamConfiguration();
+    try {
+      et.maxRetryDelay(
+          TimeUnit.SECONDS.toMillis(StreamConnectionRetry.DEFAULT_MIN_DELAY_SECONDS) - 1,
+          TimeUnit.MILLISECONDS);
+      fail("did not throw on very low max delay");
+    } catch (IllegalArgumentException ignored) {
+    }
+
+    et.maxRetryDelay(TimeUnit.SECONDS.toMillis(StreamConnectionRetry.DEFAULT_MIN_DELAY_SECONDS),
+        TimeUnit.MILLISECONDS);
+    et.maxRetryDelay(TimeUnit.SECONDS.toMillis(StreamConnectionRetry.DEFAULT_MIN_DELAY_SECONDS) + 1,
+        TimeUnit.MILLISECONDS);
+  }
 
   @Test
   public void testTypeCheck() {

--- a/nakadi-java-zign/build.gradle
+++ b/nakadi-java-zign/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 
 
 dependencies {
-  compile project(':  nakadi-java-client')
+  compile project(':nakadi-java-client')
   compile project.libs.slf4j
 
   testCompile project.libs.logback_core


### PR DESCRIPTION
When a client handling a partition goes away, the other running clients
will compete to grab it once they wake up and retry. They work by retrying
every N seconds to see if a partition is available and then fall back to
sleep if none are. The aim here is to avoid any need for special level
handling to manage down the number of client connections by the caller.
It should be ok to run the client across your very large microservices
cluster such that even for just a few partitions, they won't hammer the
broker.

This stops the client accepting a value that could cause too many requests;
picking 1s for now, might need to change later.

For #83.