### PR TITLE
Extend RetryPolicy to support max time backoff.

### DIFF
--- a/nakadi-java-client/src/test/java/nakadi/ExponentialRetryTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/ExponentialRetryTest.java
@@ -1,0 +1,87 @@
+package nakadi;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ExponentialRetryTest {
+
+  @Test
+  public void tempusFugit() throws Exception {
+
+    ExponentialRetry exponentialRetry = ExponentialRetry.newBuilder()
+        .initialInterval(1, TimeUnit.MILLISECONDS)
+        .maxAttempts(Integer.MAX_VALUE)
+        .maxInterval(3, TimeUnit.MILLISECONDS)
+        .maxTime(3, TimeUnit.SECONDS)
+        .build();
+
+    while(true) {
+      long l = exponentialRetry.nextBackoffMillis();
+      if(l == -1) {
+        break;
+      }
+      Thread.sleep(l);
+    }
+
+    assertTrue(exponentialRetry.workingTime >= exponentialRetry.maxTime);
+    assertTrue(exponentialRetry.workingAttempts < exponentialRetry.maxAttempts);
+
+    exponentialRetry = ExponentialRetry.newBuilder()
+        .maxTime(3, TimeUnit.SECONDS)
+        .maxInterval(100, TimeUnit.MILLISECONDS)
+        .build();
+
+    while(true) {
+      long l = exponentialRetry.nextBackoffMillis();
+      if(l == -1) {
+        break;
+      }
+      Thread.sleep(l);
+    }
+
+    assertTrue(exponentialRetry.workingTime >= exponentialRetry.maxTime);
+    assertTrue(exponentialRetry.workingAttempts < exponentialRetry.maxAttempts);
+  }
+
+  @Test
+  public void annumero() throws Exception {
+
+    ExponentialRetry exponentialRetry = ExponentialRetry.newBuilder()
+        .initialInterval(1, TimeUnit.MILLISECONDS)
+        .maxAttempts(20)
+        .maxInterval(100, TimeUnit.MILLISECONDS)
+        .maxTime(Integer.MAX_VALUE, TimeUnit.SECONDS)
+        .build();
+
+    while(true) {
+      long l = exponentialRetry.nextBackoffMillis();
+      if(l == -1) {
+        break;
+      }
+      Thread.sleep(l);
+    }
+
+    assertTrue(exponentialRetry.workingTime < exponentialRetry.maxTime);
+    assertTrue(exponentialRetry.workingAttempts >= exponentialRetry.maxAttempts);
+
+
+    exponentialRetry = ExponentialRetry.newBuilder()
+        .maxAttempts(3)
+        .maxInterval(100, TimeUnit.MILLISECONDS)
+        .build();
+
+    while(true) {
+      long l = exponentialRetry.nextBackoffMillis();
+      if(l == -1) {
+        break;
+      }
+      Thread.sleep(l);
+    }
+
+    assertTrue(exponentialRetry.workingTime < exponentialRetry.maxTime);
+    assertTrue(exponentialRetry.workingAttempts >= exponentialRetry.maxAttempts);
+  }
+
+}


### PR DESCRIPTION
This provides an option to bound retries by time regardless of the number of
attempts. Event producers that want to bound the total amount of time sending
an event before giving up, and the subscription stream checkpointer are the
main examples in the client that would find it useful to exist based on time
elapse rather than number of attempts.

For #81.