### PR TITLE
Replace application/x-json-stream with application/json.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ### Changes
 
+### 0.6.2
+
+- Change streaming accept header to application/json [#98](https://github.com/zalando-incubator/nakadi-java/issues/98)
+
 ### 0.6.1
 
 - Allow blocking access to streams

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 - Build: [![CircleCI](https://circleci.com/gh/zalando-incubator/nakadi-java.svg?style=svg)](https://circleci.com/gh/zalando-incubator/nakadi-java)
 - Release Download: [ ![Download](https://api.bintray.com/packages/dehora/maven/nakadi-java-client/images/download.svg) ](https://bintray.com/dehora/maven/nakadi-java-client/_latestVersion)
-- Source Release: [0.6.1](https://github.com/zalando-incubator/nakadi-java/releases/tag/0.6.1)
+- Source Release: [0.6.2](https://github.com/zalando-incubator/nakadi-java/releases/tag/0.6.2)
 - Contact: [maintainers](https://github.com/zalando-incubator/nakadi-java/blob/master/MAINTAINERS)
 
 
@@ -95,7 +95,7 @@ The client's had some basic testing to verify it can handle things like
 consumer stream connection/network failures and retries. It should not be 
 deemed robust yet, but it is a goal to produce a well-behaved production 
 level client especially for producing and consuming events for 1.0.0. The 
-releases from 0.6.1 and onwards seem fairly sane.
+releases from 0.6.2 and onwards seem fairly sane.
 
 See also:
 
@@ -623,7 +623,7 @@ and add the project declaration to `pom.xml`:
 <dependency>
   <groupId>net.dehora.nakadi</groupId>
   <artifactId>nakadi-java-client</artifactId>
-  <version>0.6.1</version>
+  <version>0.6.2</version>
 </dependency>
 ```
 ### Gradle
@@ -640,7 +640,7 @@ and add the project to the `dependencies` block in `build.gradle`:
 
 ```groovy
 dependencies {
-  compile 'net.dehora.nakadi:nakadi-java-client:0.6.1'
+  compile 'net.dehora.nakadi:nakadi-java-client:0.6.2'
 }  
 ```
 
@@ -655,7 +655,7 @@ resolvers += "jcenter" at "http://jcenter.bintray.com"
 and add the project to `libraryDependencies` in `build.sbt`:
 
 ```scala
-libraryDependencies += "net.dehora.nakadi" % "nakadi-java-client" % "0.6.1"
+libraryDependencies += "net.dehora.nakadi" % "nakadi-java-client" % "0.6.2"
 ```
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # suppress inspection "UnusedProperty" for whole file
 org.gradle.daemon=true
-version=0.6.1
+version=0.6.2
 group=net.dehora.nakadi
 # one per line to keep diffs clean
 modules=\

--- a/nakadi-java-client/src/main/java/nakadi/StreamResourceSupport.java
+++ b/nakadi-java-client/src/main/java/nakadi/StreamResourceSupport.java
@@ -21,6 +21,7 @@ class StreamResourceSupport {
   private static final String PATH_SUBS = "subscriptions";
   private static final String PATH_EVENTS = "events";
   private static final String APPLICATION_X_JSON_STREAM = "application/x-json-stream";
+  private static final String APPLICATION_JSON = "application/json";
   private static final String HEADER_X_NAKADI_CURSORS = "X-Nakadi-Cursors";
 
   static String buildStreamUrl(URI baseUri, StreamConfiguration sc) {
@@ -46,7 +47,8 @@ class StreamResourceSupport {
   static ResourceOptions buildResourceOptions(NakadiClient client, StreamConfiguration sc,
      String scope) {
     ResourceOptions options = ResourceSupport
-        .options(APPLICATION_X_JSON_STREAM)
+        // breaks with api definition https://github.com/zalando-incubator/nakadi-java/issues/98
+        .options(APPLICATION_JSON)
         .scope(Optional.ofNullable(scope).orElseGet(() -> TokenProvider.NAKADI_EVENT_STREAM_READ))
         .tokenProvider(client.resourceTokenProvider());
 

--- a/nakadi-java-client/src/main/java/nakadi/Version.java
+++ b/nakadi-java-client/src/main/java/nakadi/Version.java
@@ -2,5 +2,5 @@ package nakadi;
 
 public class Version {
 
-  public static final String VERSION = "0.6.1";
+  public static final String VERSION = "0.6.2";
 }


### PR DESCRIPTION
The API definition documents only accepting application/x-json-stream,
but current Nakadi servers reject it with a 406 (they accept no
media type or application/json). Patching on the client for now until
the server definition/implementation is fixed.

For #98.