### PR TITLE
Add back pressure buffering to stream processor.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ### Changes
 
+### 0.6.3
+
+Add back pressure buffering to stream processor for volume stream requests.  [#100](https://github.com/zalando-incubator/nakadi-java/issues/100)
+
 ### 0.6.2
 
 - Change streaming accept header to application/json [#98](https://github.com/zalando-incubator/nakadi-java/issues/98)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 - Build: [![CircleCI](https://circleci.com/gh/zalando-incubator/nakadi-java.svg?style=svg)](https://circleci.com/gh/zalando-incubator/nakadi-java)
 - Release Download: [ ![Download](https://api.bintray.com/packages/dehora/maven/nakadi-java-client/images/download.svg) ](https://bintray.com/dehora/maven/nakadi-java-client/_latestVersion)
-- Source Release: [0.6.2](https://github.com/zalando-incubator/nakadi-java/releases/tag/0.6.2)
+- Source Release: [0.6.3](https://github.com/zalando-incubator/nakadi-java/releases/tag/0.6.3)
 - Contact: [maintainers](https://github.com/zalando-incubator/nakadi-java/blob/master/MAINTAINERS)
 
 
@@ -97,7 +97,7 @@ The client's had some basic testing to verify it can handle things like
 consumer stream connection/network failures and retries. It should not be 
 deemed robust yet, but it is a goal to produce a well-behaved production 
 level client especially for producing and consuming events for 1.0.0. The 
-releases from 0.6.2 and onwards seem fairly sane.
+releases from 0.6.3 and onwards seem fairly sane.
 
 See also:
 
@@ -641,7 +641,7 @@ and add the project declaration to `pom.xml`:
 <dependency>
   <groupId>net.dehora.nakadi</groupId>
   <artifactId>nakadi-java-client</artifactId>
-  <version>0.6.2</version>
+  <version>0.6.3</version>
 </dependency>
 ```
 ### Gradle
@@ -658,7 +658,7 @@ and add the project to the `dependencies` block in `build.gradle`:
 
 ```groovy
 dependencies {
-  compile 'net.dehora.nakadi:nakadi-java-client:0.6.2'
+  compile 'net.dehora.nakadi:nakadi-java-client:0.6.3'
 }  
 ```
 
@@ -673,7 +673,7 @@ resolvers += "jcenter" at "http://jcenter.bintray.com"
 and add the project to `libraryDependencies` in `build.sbt`:
 
 ```scala
-libraryDependencies += "net.dehora.nakadi" % "nakadi-java-client" % "0.6.2"
+libraryDependencies += "net.dehora.nakadi" % "nakadi-java-client" % "0.6.3"
 ```
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # suppress inspection "UnusedProperty" for whole file
 org.gradle.daemon=true
-version=0.6.2
+version=0.6.3
 group=net.dehora.nakadi
 # one per line to keep diffs clean
 modules=\

--- a/nakadi-java-client/src/main/java/nakadi/LoggingStreamObserver.java
+++ b/nakadi-java-client/src/main/java/nakadi/LoggingStreamObserver.java
@@ -13,6 +13,8 @@ public class LoggingStreamObserver extends StreamObserverBackPressure<String> {
 
   private static final Logger logger = LoggerFactory.getLogger(NakadiClient.class.getSimpleName());
 
+  static int eventCount = 0;
+
   @Override public void onStart() {
     logger.info("LoggingStreamObserver.onStart");
   }
@@ -49,7 +51,7 @@ public class LoggingStreamObserver extends StreamObserverBackPressure<String> {
               "LoggingStreamObserver events processing count {} =====================================",
               events.size());
           for (String event : events) {
-            logger.info("LoggingStreamObserver received event: {}", event);
+            logger.info("LoggingStreamObserver received count {} event: {}", ++eventCount, event);
           }
           offsetObserver.onNext(record.streamCursorContext());
           logger.info(

--- a/nakadi-java-client/src/main/java/nakadi/StreamBatchRecordBufferingSubscriber.java
+++ b/nakadi-java-client/src/main/java/nakadi/StreamBatchRecordBufferingSubscriber.java
@@ -30,6 +30,7 @@ class StreamBatchRecordBufferingSubscriber<T> extends Subscriber<List<StreamBatc
       observer.onNext(record);
     });
     // allow the observer to set back pressure
+    // todo: revisit this for high volume streams
     observer.requestBackPressure().ifPresent(this::request);
   }
 }

--- a/nakadi-java-client/src/main/java/nakadi/StreamProcessor.java
+++ b/nakadi-java-client/src/main/java/nakadi/StreamProcessor.java
@@ -235,6 +235,7 @@ public class StreamProcessor implements StreamProcessorManaged {
             )
                 .subscribeOn(monoIoScheduler)
                 .unsubscribeOn(monoIoScheduler)
+                .onBackpressureBuffer(Integer.MAX_VALUE)
                 .doOnSubscribe(streamObserver::onStart)
                 .doOnUnsubscribe(streamObserver::onStop)
                 .timeout(halfOpenKick, halfOpenUnit)
@@ -315,8 +316,9 @@ public class StreamProcessor implements StreamProcessorManaged {
 
       final BufferedReader br = new BufferedReader(response.responseBody().asReader());
       return Observable.from(br.lines()::iterator)
+          .onBackpressureBuffer(Integer.MAX_VALUE)
           .map(r -> lineToStreamBatchRecord(r, typeLiteral, response, sc))
-          .switchIfEmpty(forEmpty);
+          ;
     };
   }
 

--- a/nakadi-java-client/src/main/java/nakadi/Version.java
+++ b/nakadi-java-client/src/main/java/nakadi/Version.java
@@ -2,5 +2,5 @@ package nakadi;
 
 public class Version {
 
-  public static final String VERSION = "0.6.2";
+  public static final String VERSION = "0.6.3";
 }


### PR DESCRIPTION
This seemed to have been fixed for Observable.from in
ReactiveX/RxJava#3893, as reported in
https://github.com/ReactiveX/RxJava/issues/3892but it's happening
here. Adding onBackpressureBuffer after switchIfEmpty looks to
help the situation as per this patch

For #100.