### PR TITLE
Add experimental access to schema and schema versions.

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/EventMetadata.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventMetadata.java
@@ -17,6 +17,7 @@ public class EventMetadata {
   private List<String> parentEids;
   private String flowId;
   private String partition;
+  private String version;
 
   public EventMetadata() {
     this.flowId = ResourceSupport.nextFlowId();
@@ -161,8 +162,18 @@ public class EventMetadata {
     return this;
   }
 
+  /**
+   * The version of the schema used to validate this event.
+   * @return the version.
+   */
+  @Experimental
+  public String version() {
+    return version;
+  }
+
   @Override public int hashCode() {
-    return Objects.hash(eid, eventType, occurredAt, receivedAt, parentEids, flowId, partition);
+    return Objects.hash(eid, eventType, occurredAt, receivedAt, parentEids, flowId, partition,
+        version);
   }
 
   @Override public boolean equals(Object o) {
@@ -175,7 +186,8 @@ public class EventMetadata {
         Objects.equals(receivedAt, that.receivedAt) &&
         Objects.equals(parentEids, that.parentEids) &&
         Objects.equals(flowId, that.flowId) &&
-        Objects.equals(partition, that.partition);
+        Objects.equals(partition, that.partition) &&
+        Objects.equals(version, that.version);
   }
 
   @Override public String toString() {
@@ -186,6 +198,7 @@ public class EventMetadata {
         ", parentEids=" + parentEids +
         ", flowId='" + flowId + '\'' +
         ", partition='" + partition + '\'' +
+        ", version='" + version + '\'' +
         '}';
   }
 }

--- a/nakadi-java-client/src/main/java/nakadi/EventType.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventType.java
@@ -1,5 +1,6 @@
 package nakadi;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -24,6 +25,9 @@ public class EventType {
   private EventTypeOptions options;
   private List<String> readScopes = new ArrayList<>();
   private List<String> writeScopes = new ArrayList<>();
+  private String compatibilityMode;
+  private OffsetDateTime createdAt;
+  private OffsetDateTime updatedAt;
 
   /**
    * @return the event type name
@@ -237,9 +241,41 @@ public class EventType {
     return this;
   }
 
-  @Override public int hashCode() {
-    return Objects.hash(enrichmentStrategies, name, owningApplication, category, partitionStrategy,
-        schema, partitionKeyFields, eventTypeStatistics, options, readScopes, writeScopes);
+  /**
+   * The compatibility mode of the schema.
+   *
+   * @return the compatibility mode.
+   */
+  @Experimental
+  public String compatibilityMode() {
+    return compatibilityMode;
+  }
+
+  /**
+   * Set the compatibility mode of the schema.
+   *
+   * @return this.
+   */
+  @Experimental
+  public EventType compatibilityMode(String compatibilityMode) {
+    this.compatibilityMode = compatibilityMode;
+    return this;
+  }
+
+  /**
+   * @return the time the event type was created.
+   */
+  @Experimental
+  public OffsetDateTime createdAt() {
+    return createdAt;
+  }
+
+  /**
+   * @return the time the event type was updated.
+   */
+  @Experimental
+  public OffsetDateTime updatedAt() {
+    return updatedAt;
   }
 
   @Override public boolean equals(Object o) {
@@ -256,7 +292,14 @@ public class EventType {
         Objects.equals(eventTypeStatistics, eventType.eventTypeStatistics) &&
         Objects.equals(options, eventType.options) &&
         Objects.equals(readScopes, eventType.readScopes) &&
-        Objects.equals(writeScopes, eventType.writeScopes);
+        Objects.equals(writeScopes, eventType.writeScopes) &&
+        Objects.equals(compatibilityMode, eventType.compatibilityMode);
+  }
+
+  @Override public int hashCode() {
+    return Objects.hash(enrichmentStrategies, name, owningApplication, category, partitionStrategy,
+        schema, partitionKeyFields, eventTypeStatistics, options, readScopes, writeScopes,
+        compatibilityMode);
   }
 
   @Override public String toString() {
@@ -271,6 +314,7 @@ public class EventType {
         ", options=" + options +
         ", readScopes=" + readScopes +
         ", writeScopes=" + writeScopes +
+        ", compatibilityMode='" + compatibilityMode + '\'' +
         '}';
   }
 

--- a/nakadi-java-client/src/main/java/nakadi/EventTypeResource.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventTypeResource.java
@@ -139,4 +139,19 @@ public interface EventTypeResource {
   Partition partition(String eventTypeName, String partitionId)
       throws AuthorizationException, ClientException, ServerException, InvalidException,
       RateLimitException, NakadiException;
+
+  /**
+   * @return the event type schemas for the event type.
+   *
+   * @param eventTypeName the event type
+   * @throws AuthorizationException
+   * @throws ClientException
+   * @throws ServerException
+   * @throws RateLimitException
+   * @throws NakadiException
+   */
+  @Experimental
+  EventTypeSchemaCollection schemas(String eventTypeName)
+      throws AuthorizationException, ClientException, ServerException,
+      RateLimitException, NakadiException;
 }

--- a/nakadi-java-client/src/main/java/nakadi/EventTypeSchema.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventTypeSchema.java
@@ -1,5 +1,6 @@
 package nakadi;
 
+import java.time.OffsetDateTime;
 import java.util.Objects;
 
 import static nakadi.EventTypeSchema.Type.json_schema;
@@ -8,6 +9,8 @@ public class EventTypeSchema {
 
   private Type type = json_schema;
   private String schema;
+  private String version;
+  private OffsetDateTime createdAt;
 
   public Type type() {
     return type;
@@ -27,8 +30,21 @@ public class EventTypeSchema {
     return this;
   }
 
-  @Override public int hashCode() {
-    return Objects.hash(type, schema);
+  /**
+   * The version of the schema used to validate this event.
+   * @return the version.
+   */
+  @Experimental
+  public String version() {
+    return version;
+  }
+
+  /**
+   * @return the time the event type was created.
+   */
+  @Experimental
+  public OffsetDateTime createdAt() {
+    return createdAt;
   }
 
   @Override public boolean equals(Object o) {
@@ -36,12 +52,20 @@ public class EventTypeSchema {
     if (o == null || getClass() != o.getClass()) return false;
     EventTypeSchema that = (EventTypeSchema) o;
     return type == that.type &&
-        Objects.equals(schema, that.schema);
+        Objects.equals(schema, that.schema) &&
+        Objects.equals(version, that.version) &&
+        Objects.equals(createdAt, that.createdAt);
+  }
+
+  @Override public int hashCode() {
+    return Objects.hash(type, schema, version, createdAt);
   }
 
   @Override public String toString() {
     return "EventTypeSchema{" + "type=" + type +
         ", schema='" + schema + '\'' +
+        ", version='" + version + '\'' +
+        ", createdAt=" + createdAt +
         '}';
   }
 

--- a/nakadi-java-client/src/main/java/nakadi/EventTypeSchemaCollection.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventTypeSchemaCollection.java
@@ -1,0 +1,22 @@
+package nakadi;
+
+import java.util.List;
+
+/**
+ * A collection of event type schemas
+ */
+@Experimental
+public class EventTypeSchemaCollection extends ResourceCollection<EventTypeSchema> {
+
+  private final EventTypeResourceReal eventTypeResource;
+
+  public EventTypeSchemaCollection(List<EventTypeSchema> items, List<ResourceLink> links,
+      EventTypeResourceReal eventTypeResource) {
+    super(items, links);
+    this.eventTypeResource = eventTypeResource;
+  }
+
+  public ResourceCollection<EventTypeSchema> fetchPage(String url) {
+    return eventTypeResource.loadSchemaPage(url);
+  }
+}

--- a/nakadi-java-client/src/main/java/nakadi/Experimental.java
+++ b/nakadi-java-client/src/main/java/nakadi/Experimental.java
@@ -1,0 +1,20 @@
+package nakadi;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotates that a method or class is experimental. Experimental API's might change or be
+ * removed in later releases. Often they are present to support candidate features in the
+ * Nakadi API.
+ */
+@Retention(value = RUNTIME)
+@Target(value = {TYPE, METHOD, PARAMETER, CONSTRUCTOR})
+public @interface Experimental {
+}


### PR DESCRIPTION
Once the feature is fully available, `Experimental` can be removed.