### PR TITLE
Support sending events as raw strings.

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/EventContentSupplier.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventContentSupplier.java
@@ -1,0 +1,7 @@
+package nakadi;
+
+@FunctionalInterface
+interface EventContentSupplier {
+
+  byte[] content();
+}

--- a/nakadi-java-client/src/main/java/nakadi/EventResource.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventResource.java
@@ -29,6 +29,12 @@ public interface EventResource {
   /**
    * Send a batch of events to the server.
    *
+   *<p>
+   *   If the first item in events is detected to be a String, the list will be treated as raw
+   *   JSON items. Otherwise the event is serialised to JSON. This behaviour is fragile and
+   *   might be changed prior to 1.0.0, most likely by introducing a new signature for raw
+   *   JSON events.
+   * </p>
    * <p>
    *   The response may be a 207 indicating some or none of the events succeeded. See the Nakadi
    *   API definition for details.
@@ -49,7 +55,10 @@ public interface EventResource {
 
   /**
    * Send an event to the server.
-   *
+   * <p>
+   *   If the event is detected to be a String, it will be treated as raw JSON. Otherwise the
+   *   event is serialised to JSON.
+   * </p>
    * <p>
    *   <b>Warning: </b> the ordering and general delivery behaviour for event delivery is
    *   undefined under retries. That is, a delivery retry may result in out or order events being

--- a/nakadi-java-client/src/main/java/nakadi/OkHttpResource.java
+++ b/nakadi-java-client/src/main/java/nakadi/OkHttpResource.java
@@ -203,9 +203,18 @@ class OkHttpResource implements Resource {
       Req body) {
     Request.Builder builder;
     if (body != null) {
-      RequestBody requestBody = RequestBody.create(MediaType.parse(APPLICATION_JSON_CHARSET_UTF8),
-          jsonSupport.toJson(body));
-      builder = new Request.Builder().url(url).method(method, requestBody);
+      if(body instanceof EventContentSupplier) {
+        EventContentSupplier supplier = (EventContentSupplier)body;
+        RequestBody requestBody =
+            RequestBody.create(MediaType.parse(APPLICATION_JSON_CHARSET_UTF8), supplier.content());
+        builder = new Request.Builder().url(url).method(method, requestBody);
+
+      } else {
+        String content = jsonSupport.toJson(body);
+        RequestBody requestBody =
+            RequestBody.create(MediaType.parse(APPLICATION_JSON_CHARSET_UTF8), content);
+        builder = new Request.Builder().url(url).method(method, requestBody);
+      }
     } else {
       builder = applyMethodForNoBody(method, url, new Request.Builder().url(url));
     }


### PR DESCRIPTION
This allows raw strings to be submitted as well as objects. Without
detecting the string as a string, it will be double escaped by gson.
The feature's experimental and the implementation will probably
change if kept around.