### PR TITLE
Handle batch item responses for event posting.

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/BatchItemResponse.java
+++ b/nakadi-java-client/src/main/java/nakadi/BatchItemResponse.java
@@ -5,7 +5,7 @@ import java.util.Objects;
 public class BatchItemResponse {
 
   private String eid;
-  private PublishingStatus status;
+  private PublishingStatus publishing_status;
   private Step step;
   private String detail;
 
@@ -13,8 +13,8 @@ public class BatchItemResponse {
     return eid;
   }
 
-  public PublishingStatus status() {
-    return status;
+  public PublishingStatus publishingStatus() {
+    return publishing_status;
   }
 
   public Step step() {
@@ -26,7 +26,7 @@ public class BatchItemResponse {
   }
 
   @Override public int hashCode() {
-    return Objects.hash(eid, status, step, detail);
+    return Objects.hash(eid, publishing_status, step, detail);
   }
 
   @Override public boolean equals(Object o) {
@@ -34,14 +34,14 @@ public class BatchItemResponse {
     if (o == null || getClass() != o.getClass()) return false;
     BatchItemResponse that = (BatchItemResponse) o;
     return Objects.equals(eid, that.eid) &&
-        status == that.status &&
+        publishing_status == that.publishing_status &&
         step == that.step &&
         Objects.equals(detail, that.detail);
   }
 
   @Override public String toString() {
     return "BatchItemResponse{" + "eid='" + eid + '\'' +
-        ", status=" + status +
+        ", publishing_status=" + publishing_status +
         ", step=" + step +
         ", detail='" + detail + '\'' +
         '}';

--- a/nakadi-java-client/src/main/java/nakadi/BatchItemResponseCollection.java
+++ b/nakadi-java-client/src/main/java/nakadi/BatchItemResponseCollection.java
@@ -1,0 +1,17 @@
+package nakadi;
+
+import java.util.List;
+
+/**
+ * The result of a partial failure to post events.
+ */
+public class BatchItemResponseCollection extends ResourceCollection<BatchItemResponse> {
+
+  BatchItemResponseCollection(List<BatchItemResponse> items, List<ResourceLink> links) {
+    super(items, links);
+  }
+  
+  public ResourceCollection<BatchItemResponse> fetchPage(String url) {
+    throw new UnsupportedOperationException("Paging batch item responses is not supported");
+  }
+}

--- a/nakadi-java-client/src/main/java/nakadi/EventResource.java
+++ b/nakadi-java-client/src/main/java/nakadi/EventResource.java
@@ -1,6 +1,7 @@
 package nakadi;
 
 import java.util.Collection;
+import java.util.List;
 
 public interface EventResource {
 
@@ -71,5 +72,26 @@ public interface EventResource {
    * @return the response
    */
   <T> Response send(String eventTypeName, T event);
+
+
+  /**
+   * Send a batch of events to the server.
+   *
+   * <p>
+   *   If the response is 422 or 207 the BatchItemResponseCollection will contain items.
+   * </p>
+   * <p>
+   *   <b>Warning: </b> the ordering and general delivery behaviour for event delivery is
+   *   undefined under retries. That is, a delivery retry may result in out or order batches being
+   *   sent to the server. Also retrying a partially delivered (207) batch may result in one
+   *   or more events being delivered multiple times.
+   * </p>
+   *
+   * @param eventTypeName the event type name
+   * @param events the events
+   * @return a BatchItemResponseCollection which will be empty if successful or have items
+   * if the post was partially successful (via a 422 or 207 response)
+   */
+  <T> BatchItemResponseCollection sendBatch(String eventTypeName, List<T> events);
 
 }

--- a/nakadi-java-client/src/main/java/nakadi/GsonSupport.java
+++ b/nakadi-java-client/src/main/java/nakadi/GsonSupport.java
@@ -58,6 +58,10 @@ class GsonSupport implements JsonSupport {
     return gson.fromJson(r, c);
   }
 
+  @Override public <T> T fromJson(Reader r, Type tType) {
+    return gson.fromJson(r, tType);
+  }
+
   /**
    * Punch  a hole in the abstraction to let us deal with business and undefined event types that
    * can't be marshalled sanely otherwise.

--- a/nakadi-java-client/src/main/java/nakadi/JsonSupport.java
+++ b/nakadi-java-client/src/main/java/nakadi/JsonSupport.java
@@ -54,4 +54,14 @@ public interface JsonSupport {
    * @return an instance of T
    */
   <T> T fromJson(Reader r, Class<T> c);
+
+  /**
+   * Marshal the JSON data to an instance of T.
+   *
+   * @param r JSON as a Reader
+   * @param tType the type of the target
+   * @param <T> the parameterized target type
+   * @return an instance of T
+   */
+  <T> T fromJson(Reader r, Type tType);
 }

--- a/nakadi-java-client/src/main/java/nakadi/Resource.java
+++ b/nakadi-java-client/src/main/java/nakadi/Resource.java
@@ -98,6 +98,30 @@ public interface Resource {
       RateLimitException, NakadiException;
 
   /**
+   * Make a request against the server with a request entity. This method is tailored  for
+   * posting events.
+   *
+   * <p>
+   *   If the server returns 422 or 207 indicating partial failures, errors are not thrown.
+   *   Instead callers can inspect the response body for an array of batch item responses.
+   * </p>
+   *
+   * @param url the resource url
+   * @param options requestThrowing options such as headers, and tokens.
+   * @param body the object to create a JSON requestThrowing body from
+   * @param <Req> the body type
+   * @return a http response
+   * @throws AuthorizationException for 401 and 403
+   * @throws ClientException for general 4xx errors (422 does not cause an exception)
+   * @throws ServerException for general 5xx errors
+   * @throws RateLimitException for 429
+   * @throws NakadiException a non HTTP based exception
+   */
+  <Req> Response postEventsThrowing(String url, ResourceOptions options, Req body)
+      throws AuthorizationException, ClientException, ServerException, RateLimitException,
+      NakadiException;
+
+  /**
    * Make a request against the server with an expected response entity. Useful for get
    * requests. Exceptions are thrown for HTTP level errors (4xx and 5xx).
    *

--- a/nakadi-java-client/src/test/resources/err_batch_item_response_array.json
+++ b/nakadi-java-client/src/test/resources/err_batch_item_response_array.json
@@ -1,0 +1,14 @@
+[
+  {
+    "eid": "7d7574c3-42ac-4e23-8c92-cd854ab1845a",
+    "publishing_status": "failed",
+    "step": "enriching",
+    "detail": "no good"
+  },
+  {
+    "eid": "980c8aa9-7921-4675-a0c0-0b33b1459944",
+    "publishing_status": "submitted",
+    "step": "none",
+    "detail": null
+  }
+]


### PR DESCRIPTION
This supports the case when the server returns 207 or 422 for an
event post. It also provides a convenience method on EventResource
that returns a BatchItemResponseCollection instead of having to
marshal the Response content from the other send methods.

For #116.