### PR TITLE
Ignores batch limit values set to 0 or less.

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/StreamConfiguration.java
+++ b/nakadi-java-client/src/main/java/nakadi/StreamConfiguration.java
@@ -106,8 +106,19 @@ public class StreamConfiguration {
   }
 
   /**
-   * Maximum number of Events in each batch of the stream. If 0 or unspecified
-   * will buffer Events indefinitely and flush on reaching of {@link #batchFlushTimeoutSeconds()}.
+   * Maximum number of Events in each batch of the stream. The default is to not set the parameter
+   * and allow the server to define it.
+   *
+   * <p>
+   *  Note 2017/04/20: the API definition says if the value is  0 or unspecified the server will
+   *  buffer events indefinitely and flush on reaching of {@link #batchFlushTimeoutSeconds()}.
+   *  This is incorrect - if the server receives a value of '0' it will not send events at
+   *  all (effectively it's a silent bug). To compensate, if the value is set to 0 here (or
+   *  less than 1), the client will ignore the setting and not add the batch limit query parameter.
+   *  Ignoring instead of throwing makes the method compatible with previous client versions, but
+   *  this behaviour will be changed to raise an exception before 1.0.0.
+   * </p>
+   *
    */
   public StreamConfiguration batchLimit(int batchLimit) {
     this.batchLimit = batchLimit;

--- a/nakadi-java-client/src/main/java/nakadi/StreamResourceSupport.java
+++ b/nakadi-java-client/src/main/java/nakadi/StreamResourceSupport.java
@@ -84,8 +84,9 @@ class StreamResourceSupport {
    */
   private static UriBuilder applyParamsTo(UriBuilder uriBuilder, StreamConfiguration sc) {
 
-    if (sc.batchLimit() != StreamConfiguration.DEFAULT_BATCH_LIMIT) {
-      uriBuilder.query(PARAM_BATCH_LIMIT, "" + sc.batchLimit());
+    // ignores 0 or lower values: see https://github.com/zalando-incubator/nakadi-java/issues/125
+    if (sc.batchLimit() > StreamConfiguration.DEFAULT_BATCH_LIMIT) {
+        uriBuilder.query(PARAM_BATCH_LIMIT, "" + sc.batchLimit());
     }
 
     if (sc.streamLimit() != StreamConfiguration.DEFAULT_STREAM_LIMIT) {

--- a/nakadi-java-client/src/test/java/nakadi/StreamResourceSupportTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/StreamResourceSupportTest.java
@@ -93,6 +93,18 @@ public class StreamResourceSupportTest {
   }
 
   @Test
+  public void testUrlBuilderBatchLimit_gh125() {
+    // see https://github.com/zalando-incubator/nakadi-java/issues/125
+
+    StreamConfiguration et1 = new StreamConfiguration()
+        .eventTypeName("et1")
+        .batchLimit(0);
+
+    assertEquals("http://localhost:9080/event-types/et1/events",
+        StreamResourceSupport.buildStreamUrl(client.baseURI(), et1));
+  }
+
+  @Test
   public void testHeaderConfiguration() {
 
     StreamConfiguration sc = new StreamConfiguration();


### PR DESCRIPTION
A batch limit of 0 isn't a useful value despite the the API definition
describing it. Instead the server never sends events if batch limit is 0
which is a silent bug. This changes the client to ignore 0 (or lower)
values for batch limit. A future pr prior to 1.0.0 might result in an
exception being thrown but for now ignoring the value keeps with the
current client behaviour.

For #125.