### PR TITLE
Supports initial_cursors for creating Subscriptions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ Response batch = resource.send("priority-requisitions", list);
 
 ### Subscriptions
 
-You can create, edit and delete susbcriptions as well as list them:
+You can create, edit and delete subscriptions as well as list them:
 
 ```java
 // grab a subscription resource
@@ -404,7 +404,18 @@ Subscription subscription = new Subscription()
     .owningApplication("shaper");
  
 Response response = resource.create(subscription);
- 
+
+// create a subscription from a given offset
+Cursor c0 = new Cursor("0", "000000000000002009", "priority-requisitions");
+Cursor c1 = new Cursor("1", "000000000000002008", "priority-requisitions");
+
+Subscription offsetSubscription = new Subscription()
+    .consumerGroup("roja-cg")
+    .eventType("priority-requisitions")
+    .owningApplication("anarch")
+    .readFrom("cursors")
+    .initialCursors(Lists.newArrayList(c0, c1));    
+
 // find a subscription
 Subscription found = resource.find("a2ab0b7c-ee58-48e5-b96a-d13bce73d857");
  

--- a/nakadi-java-client/src/main/java/nakadi/Cursor.java
+++ b/nakadi-java-client/src/main/java/nakadi/Cursor.java
@@ -46,6 +46,17 @@ public class Cursor {
   }
 
   /**
+   * Constructor representing the Cursor model used for offset based subscriptions.
+   *
+   * @param partition the partition for the cursor
+   * @param offset the current offset
+   * @param eventType the event type for the cursor
+   */
+  public Cursor(String partition, String offset, String eventType) {
+    this(partition, offset, eventType, null);
+  }
+
+  /**
    * @return the event type if a named event stream, or {@link Optional#empty}
    */
   public Optional<String> eventType() {

--- a/nakadi-java-client/src/main/java/nakadi/NakadiException.java
+++ b/nakadi-java-client/src/main/java/nakadi/NakadiException.java
@@ -1,5 +1,7 @@
 package nakadi;
 
+import java.util.Collection;
+
 /**
  * An exception representing an error from the client. All client API exceptions extend this one.
  */
@@ -36,6 +38,19 @@ public class NakadiException extends RuntimeException {
       throw new IllegalArgumentException(message);
     }
     return arg;
+  }
+
+  /**
+   * Throw an IllegalArgumentException if the argument is null or an empty collection.
+   *
+   * @param arg the collection to check
+   * @param message the exception message
+   * @throws IllegalArgumentException if {@code obj} is {@code null} or an empty collection
+   */
+  public static void throwNotNullOrEmpty(Collection arg, String message) {
+    if (arg == null || arg.isEmpty()) {
+      throw new IllegalArgumentException(message);
+    }
   }
 
   /**

--- a/nakadi-java-client/src/test/java/nakadi/SubscriptionTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/SubscriptionTest.java
@@ -1,0 +1,49 @@
+package nakadi;
+
+import com.google.common.collect.Lists;
+import java.util.List;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class SubscriptionTest {
+
+  @Test
+  public void testCursors() {
+    Subscription subscription = new Subscription();
+
+    try {
+      subscription.initialCursors(null);
+      fail();
+    } catch (IllegalArgumentException ignored) {
+    }
+
+    try {
+      subscription.initialCursors(Lists.newArrayList());
+      fail();
+    } catch (IllegalArgumentException ignored) {
+    }
+
+
+    Cursor cursor = new Cursor("p", "o");
+    try {
+      subscription.initialCursors(Lists.newArrayList(cursor));
+      fail();
+    } catch (IllegalArgumentException ignored) {
+    }
+
+    cursor = new Cursor("p", "o", "e", "t");
+
+    subscription.initialCursors(Lists.newArrayList(cursor));
+    List<Cursor> cursors = subscription.initialCursors();
+    assertTrue(cursors.size() == 1);
+    assertFalse(cursors.get(0).cursorToken().isPresent());
+    assertEquals("p", cursors.get(0).partition());
+    assertEquals("o", cursors.get(0).offset());
+    assertEquals("e", cursors.get(0).eventType().get());
+
+  }
+}


### PR DESCRIPTION
This allows clients to create a Subscription from a known set of
partition offsets. The cursor list is validated to be non-null
and not empty, otherwise validations are left to the server.

For #139.