### PR TITLE
Allows a specific cert to be loaded from the classpath.

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,11 +210,26 @@ NakadiClient client = NakadiClient.newBuilder()
   .build();
 ```
 
-This will cause the client to install any certificates it finds in the 
-supplied directory; files with `*.crt` and `*.pem` extensions are loaded. The 
-path must begin with `"file:///"` or `"classpath:"` to indicate whether the 
-certs are loaded from a file directory or  the classpath. If no 
-`certificatePath` is supplied, the system defaults are used.
+This will cause the client to install any certificates it finds. There are three 
+loading options
+
+- A path beginning with `"file:///"` will load from the supplied directory any 
+files with `*.crt` and `*.pem` extensions
+
+- A path beginning with `"classpath:"` and ending with `*.crt` or `*.pem` will 
+load that resource item from the classpath. 
+ 
+- A path beginning with `"classpath:"` will load from the supplied classpath 
+directory any files with `*.crt` and `*.pem` extensions.
+
+
+The classpath option targeting a directory is for local development and not meant 
+for production/deployed situations. If you must use the classpath for deployed apps, 
+use the cert resource option as that will allow the classpath resolver to work more 
+ generally.
+
+If no `certificatePath` is supplied, the system defaults are used. This is the 
+strongly recommended option for deployments.
 
 #### Metric Collector
 

--- a/nakadi-java-client/src/test/java/nakadi/SecuritySupportTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/SecuritySupportTest.java
@@ -45,6 +45,28 @@ public class SecuritySupportTest {
   }
 
   @Test
+  public void createOne() throws IOException {
+    SecuritySupport securitySupport = new SecuritySupport("classpath:certs/letsencryptauthorityx1.pem");
+    X509TrustManager x509TrustManager = securitySupport.trustManager();
+    SSLContext sslContext = securitySupport.sslContext();
+    assertNotNull(x509TrustManager);
+    assertNotNull(sslContext);
+
+    X509Certificate[] acceptedIssuers = x509TrustManager.getAcceptedIssuers();
+    assertEquals(1, acceptedIssuers.length);
+    String issuer1 = "CN=Let's Encrypt Authority X1, O=Let's Encrypt, C=US";
+    Set<String> seen = Sets.newHashSet();
+    for (X509Certificate acceptedIssuer : acceptedIssuers) {
+      String name = acceptedIssuer.getSubjectDN().getName();
+      if (issuer1.equals(name)) {
+        seen.add(name);
+      }
+    }
+    assertEquals(1, seen.size());
+    assertTrue(seen.contains(issuer1));
+  }
+
+  @Test
   public void createSome() throws IOException {
     /*
     certs contains the 2 letsencrypt root, with .crt and .pem file extensions


### PR DESCRIPTION
The existing classpath resolver only works when the classpath is
on the filesystem (it scans for files in the supplied folder).
This allows a specific cert ending in pem or crt to be stated,
which should work better with regular classpath resource resolution.

It's preferable to load certs from the keystore. The file and
classpath options are primarily for letting people develop locally
with self-signed certs.

For #126.