### PR TITLE
0.8.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ### Changes
 
+### 0.8.0
+
+- Promotes 0.7.13 to 0.8.0
+
 ### 0.7.13
 
 - Coerces raw string event posting to UTF-8. [124](https://github.com/zalando-incubator/nakadi-java/issues/124)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 - Build: [![CircleCI](https://circleci.com/gh/zalando-incubator/nakadi-java.svg?style=svg)](https://circleci.com/gh/zalando-incubator/nakadi-java)
 - Release Download: [ ![Download](https://api.bintray.com/packages/dehora/maven/nakadi-java-client/images/download.svg) ](https://bintray.com/dehora/maven/nakadi-java-client/_latestVersion)
-- Source Release: [0.7.13](https://github.com/zalando-incubator/nakadi-java/releases/tag/0.7.13)
+- Source Release: [0.8.0](https://github.com/zalando-incubator/nakadi-java/releases/tag/0.8.0)
 - Contact: [maintainers](https://github.com/zalando-incubator/nakadi-java/blob/master/MAINTAINERS)
 
 
@@ -97,7 +97,7 @@ The client's had some basic testing to verify it can handle things like
 consumer stream connection/network failures and retries. It should not be 
 deemed robust yet, but it is a goal to produce a well-behaved production 
 level client especially for producing and consuming events for 1.0.0. The 
-releases from 0.7.13 and onwards seem fairly sane.
+releases from 0.8.0 and onwards seem fairly sane.
 
 See also:
 
@@ -667,7 +667,7 @@ and add the project declaration to `pom.xml`:
 <dependency>
   <groupId>net.dehora.nakadi</groupId>
   <artifactId>nakadi-java-client</artifactId>
-  <version>0.7.13</version>
+  <version>0.8.0</version>
 </dependency>
 ```
 ### Gradle
@@ -684,7 +684,7 @@ and add the project to the `dependencies` block in `build.gradle`:
 
 ```groovy
 dependencies {
-  compile 'net.dehora.nakadi:nakadi-java-client:0.7.13'
+  compile 'net.dehora.nakadi:nakadi-java-client:0.8.0'
 }  
 ```
 
@@ -699,7 +699,7 @@ resolvers += "jcenter" at "http://jcenter.bintray.com"
 and add the project to `libraryDependencies` in `build.sbt`:
 
 ```scala
-libraryDependencies += "net.dehora.nakadi" % "nakadi-java-client" % "0.7.13"
+libraryDependencies += "net.dehora.nakadi" % "nakadi-java-client" % "0.8.0"
 ```
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # suppress inspection "UnusedProperty" for whole file
 org.gradle.daemon=true
-version=0.7.13
+version=0.8.0
 group=net.dehora.nakadi
 # one per line to keep diffs clean
 modules=\

--- a/nakadi-java-client/src/main/java/nakadi/Version.java
+++ b/nakadi-java-client/src/main/java/nakadi/Version.java
@@ -2,5 +2,5 @@ package nakadi;
 
 public class Version {
 
-  public static final String VERSION = "0.7.13";
+  public static final String VERSION = "0.8.0";
 }


### PR DESCRIPTION
Promotes 0.7.13 to 0.8.0. Rollup of 0.7.x releases:

### 0.7.13

- Coerces raw string event posting to UTF-8. [124](https://github.com/zalando-incubator/nakadi-java/issues/124)
- Allows a specific cert to be loaded from the classpath. [126](https://github.com/zalando-incubator/nakadi-java/issues/126)
- Fixes integers in BusinessEventMapped being serialised to floats. [119](https://github.com/zalando-incubator/nakadi-java/issues/119)

### 0.7.12

- Adds support for requesting `consumed_offset` per partition. [155](https://github.com/zalando-incubator/nakadi-java/issues/155)
- Adds support for requesting cursor lag. [153](https://github.com/zalando-incubator/nakadi-java/issues/153)
- Adds support for requesting cursor shifts. [#152](https://github.com/zalando-incubator/nakadi-java/issues/152)
- Adds support for cursor distance checks. [#151](https://github.com/zalando-incubator/nakadi-java/issues/151)

### 0.7.11

- Allows batch offset data to be routed to one or more subscribers.
- Allows the checkpointer to be provided in configuration.
- Allows 422 exceptions from offset commits to be suppressed [#117](https://github.com/zalando-incubator/nakadi-java/pull/117).
- Adds a marker interface, `@Unstable` for candidate API classes and methods.
- Extracts the subscription checkpoint API call to a utility checkpointer class.

### 0.7.10

- Fixes retry handling preventing per stream event batches being emitted to observers.
- Exposes number of retries to date in RetryPolicy.
- Fixes retry delay timer to honor backoff times.

### 0.7.9

- Supports initial_cursors for creating Subscriptions. [#139](https://github.com/zalando-incubator/nakadi-java/pull/139)
- Upgrades stream processors and resources to RxJava2.
- Upgrades OkHttp to 3.7.0

### 0.7.8

- Ignores batch limit values set to 0 or less. [#125](https://github.com/zalando-incubator/nakadi-java/pull/125)

### 0.7.7

- Fixes generic event types: Event becomes `Event<T>` [#130](https://github.com/zalando-incubator/nakadi-java/pull/130)

### 0.7.6

- Tests behaviour for Accept-Encoding: gzip from consumers. [#127](https://github.com/zalando-incubator/nakadi-java/issues/127)

### 0.7.5

- Handle batch item responses for event posting. [#116](https://github.com/zalando-incubator/nakadi-java/issues/116)

### 0.7.4

- Add support for posting raw JSON strings.

### 0.7.3

- Add experimental support for schema versioning to track the Nakadi API.

### 0.7.2

- Capture metrics and add more logging for checkpoint requests.
- Use a new http logger that elides auth and log to SLF4J

### 0.7.1

- Give StreamProcessor scheduler threads specific names.
- Block the caller on StreamProcessor.startBlocking, mark method as deprecated

