### PR TITLE
Works around zalando/nakadi#645.

### DIFF
--- a/nakadi-java-client/src/test/java/nakadi/ProblemSupportTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/ProblemSupportTest.java
@@ -1,0 +1,76 @@
+package nakadi;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ProblemSupportTest {
+
+  private final GsonSupport jsonSupport = new GsonSupport();
+
+  @Test
+  public void toProblemForNakadi645() {
+
+    // test workarounds for https://github.com/zalando/nakadi/issues/645
+
+    Response response = buildReponse(TestSupport.load("nakadi-645-invalid-problem-401.json"), 401);
+    Problem problem = ProblemSupport.toProblem(response, jsonSupport);
+    assertEquals("token_assumed_unauthorized", problem.title());
+    assertEquals(401, problem.status());
+
+    response = buildReponse(TestSupport.load("nakadi-645-invalid-problem-400.json"), 400);
+    problem = ProblemSupport.toProblem(response, jsonSupport);
+    assertEquals("token_assumed_rejected", problem.title());
+    // check we map the 400 onto 401
+    assertEquals(401, problem.status());
+  }
+
+  private Response buildReponse(String json, int code) {
+    return new Response() {
+      @Override public int statusCode() {
+        return code;
+      }
+
+      @Override public String reason() {
+        return "401 Unauthorized";
+      }
+
+      @Override public Map<String, List<String>> headers() {
+        return null;
+      }
+
+      @Override public ResponseBody responseBody() {
+        return new ResponseBody() {
+          @Override public String asString() throws ContractRetryableException {
+            return json;
+          }
+
+          @Override public Reader asReader() {
+            return null;
+          }
+
+          @Override public InputStream asInputStream() {
+            return null;
+          }
+
+          @Override public String mediaTypeString() {
+            return null;
+          }
+
+          @Override public long contentLength() {
+            return 0;
+          }
+
+          @Override public void close() throws IOException {
+
+          }
+        };
+      }
+    };
+  }
+}

--- a/nakadi-java-client/src/test/resources/nakadi-645-invalid-problem-400.json
+++ b/nakadi-java-client/src/test/resources/nakadi-645-invalid-problem-400.json
@@ -1,0 +1,4 @@
+{
+  "error": "invalid_request",
+  "error_description": "Retrieving information to 'accessToken' failed."
+}

--- a/nakadi-java-client/src/test/resources/nakadi-645-invalid-problem-401.json
+++ b/nakadi-java-client/src/test/resources/nakadi-645-invalid-problem-401.json
@@ -1,0 +1,4 @@
+{
+  "error": "unauthorized",
+  "error_description": "Full authentication is required to access this resource"
+}


### PR DESCRIPTION
The server doesn't return the correct response code or structure
for some auth issues. This is hack to inspect the response returned
by the server to allow auth errors to be retryable and provide
usable diagnostics to end users.

For #188.
See also: 3f3d2660be1b4e70eafb0033e6a9b700e44d1523.
See: zalando/nakadi#645