### PR TITLE
Uses unexpected json structure to workaround zalando/nakadi#645.

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/ProblemSupport.java
+++ b/nakadi-java-client/src/main/java/nakadi/ProblemSupport.java
@@ -16,13 +16,7 @@ class ProblemSupport {
 
     if (problem.status() == 0 && (response.statusCode() == 400 || response.statusCode() == 401)) {
 
-      if (raw.contains("'accessToken' failed")) {
-        problem = Problem.authProblem("token_assumed_rejected",
-            "Inferred from invalid response there was a token issue, "
-                + "see https://github.com/zalando/nakadi/issues/645 raw_response=" + raw);
-      }
-
-      if (raw.contains("authentication") || raw.contains("unauthorized")) {
+      if (raw.contains("\"error_description\"")) {
         problem = Problem.authProblem("token_assumed_unauthorized",
             "Inferred from invalid response there was an auth issue, "
                 + "see https://github.com/zalando/nakadi/issues/645 raw_response=" + raw);

--- a/nakadi-java-client/src/test/java/nakadi/ProblemSupportTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/ProblemSupportTest.java
@@ -25,7 +25,7 @@ public class ProblemSupportTest {
 
     response = buildReponse(TestSupport.load("nakadi-645-invalid-problem-400.json"), 400);
     problem = ProblemSupport.toProblem(response, jsonSupport);
-    assertEquals("token_assumed_rejected", problem.title());
+    assertEquals("token_assumed_unauthorized", problem.title());
     // check we map the 400 onto 401
     assertEquals(401, problem.status());
   }


### PR DESCRIPTION
The server doesn't return the correct response code or structure for some auth issues. 

For #188.
See also: #189.
See: zalando/nakadi#645