### PR TITLE
Allows JsonSupport implementation to be supplied to the client.

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/NakadiClient.java
+++ b/nakadi-java-client/src/main/java/nakadi/NakadiClient.java
@@ -270,5 +270,15 @@ public class NakadiClient {
       this.certificatePath = path;
       return this;
     }
+
+    /**
+     * Optionally set the {@link JsonSupport}.
+     *
+     * @return this
+     */
+    public Builder jsonSupport(JsonSupport jsonSupport) {
+      this.jsonSupport = jsonSupport;
+      return this;
+    }
   }
 }

--- a/nakadi-java-client/src/test/java/nakadi/JsonSupportNoop.java
+++ b/nakadi-java-client/src/test/java/nakadi/JsonSupportNoop.java
@@ -1,0 +1,61 @@
+package nakadi;
+
+import java.io.Reader;
+import java.lang.reflect.Type;
+import java.util.Objects;
+
+public class JsonSupportNoop implements JsonSupport {
+
+  String name;
+
+  public JsonSupportNoop(String name) {
+    this.name = name;
+  }
+
+  @Override public String toJsonCompressed(Object o) {
+    return null;
+  }
+
+  @Override public String toJson(Object o) {
+    return null;
+  }
+
+  @Override public byte[] toJsonBytes(Object o) {
+    return new byte[0];
+  }
+
+  @Override public <T> T fromJson(String raw, Class<T> c) {
+    return null;
+  }
+
+  @Override public <T> T fromJson(String raw, Type tType) {
+    return null;
+  }
+
+  @Override public <T> T fromJson(Reader r, Class<T> c) {
+    return null;
+  }
+
+  @Override public <T> T fromJson(Reader r, Type tType) {
+    return null;
+  }
+
+  @Override public <T> Object transformEventRecord(EventRecord<T> er) {
+    return null;
+  }
+
+  @Override public <T> EventStreamBatch<T> marshalEventStreamBatch(String raw, Type type) {
+    return null;
+  }
+
+  @Override public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    JsonSupportNoop that = (JsonSupportNoop) o;
+    return Objects.equals(name, that.name);
+  }
+
+  @Override public int hashCode() {
+    return Objects.hash(name);
+  }
+}

--- a/nakadi-java-client/src/test/java/nakadi/NakadiClientTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/NakadiClientTest.java
@@ -5,10 +5,30 @@ import java.util.List;
 import java.util.Map;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class NakadiClientTest {
+
+  @Test
+  public void testBuilderJsonSupportCanBeSet() {
+
+    final JsonSupportNoop jsonSupport = new JsonSupportNoop("test");
+    final NakadiClient client = NakadiClient.newBuilder()
+        .baseURI("http://example.org")
+        .jsonSupport(jsonSupport)
+        .build();
+
+    assertEquals("expected supplied json support", jsonSupport, client.jsonSupport());
+
+    final NakadiClient client1 = NakadiClient.newBuilder()
+        .baseURI("http://example.org")
+        .build();
+
+    assertNotNull("expected default json support", client1.jsonSupport());
+  }
 
   @Test
   public void testBuilderJson() {


### PR DESCRIPTION
This allows third party setting of JsonSupport and is useful for
cases where control over marshalling/serialization is needed, eg
when using Jackson or Gson custom annotations.

For #182.