### PR TITLE
Removes deprecated means to suppress invalid exceptions.

### DIFF
--- a/nakadi-java-client/src/main/java/nakadi/SubscriptionOffsetCheckpointer.java
+++ b/nakadi-java-client/src/main/java/nakadi/SubscriptionOffsetCheckpointer.java
@@ -18,20 +18,6 @@ public class SubscriptionOffsetCheckpointer {
   }
 
   /**
-   * This is deprecated and will be removed in 0.9.0. Prefer setting the
-   * {@link #suppressInvalidSessionException} method instead.
-   *
-   * @param client the client
-   * @param suppressingInvalidSessions whether or not to throw invalid session responses
-   */
-  @Deprecated
-  public SubscriptionOffsetCheckpointer(
-      NakadiClient client, @Deprecated boolean suppressingInvalidSessions) {
-    this.client = client;
-    this.suppressInvalidSessionException = suppressingInvalidSessions;
-  }
-
-  /**
    * If true tells the checkpointer to suppress invalid session responses from the server instead
    * of throwing {@link NetworkException}.
    *
@@ -64,24 +50,6 @@ public class SubscriptionOffsetCheckpointer {
    */
   public void checkpoint(StreamCursorContext context) {
     checkpointInner(context, suppressInvalidSessionException, suppressNetworkException);
-  }
-
-  /**
-   * Ask the server to commit the supplied {@link StreamCursorContext} moving the subscription
-   * offset to that point.
-   * <p>
-   * This is deprecated and will be removed in 0.9.0. Prefer setting the
-   * {@link #suppressInvalidSessionException} method instead and calling
-   * {@link #checkpoint(StreamCursorContext)}.
-   * </p>
-   *
-   * @param context holds the cursor information.
-   * @param suppressUnknownSessionError if true this will not throw 422 errors. See <a
-   * href="https://github.com/zalando-incubator/nakadi-java/issues/117">issue 117</a> for details.
-   */
-  @Deprecated
-  public void checkpoint(StreamCursorContext context, boolean suppressUnknownSessionError) {
-    checkpointInner(context, suppressUnknownSessionError, suppressNetworkException);
   }
 
   private void checkpointInner(

--- a/nakadi-java-client/src/test/java/nakadi/StreamProcessorTest.java
+++ b/nakadi-java-client/src/test/java/nakadi/StreamProcessorTest.java
@@ -607,7 +607,8 @@ public class StreamProcessorTest {
 
     assertNotNull(sp);
 
-    SubscriptionOffsetCheckpointer checkpointer = new SubscriptionOffsetCheckpointer(client, true);
+    SubscriptionOffsetCheckpointer checkpointer = new SubscriptionOffsetCheckpointer(client)
+        .suppressInvalidSessionException(true);
     final StreamProcessor sp1 = StreamProcessor.newBuilder(client)
         .checkpointer(checkpointer)
         .streamConfiguration(new StreamConfiguration().subscriptionId("s1"))
@@ -667,7 +668,8 @@ public class StreamProcessorTest {
   @Test
   public void testBuilderSubscriptionOffsetPublisher() throws Exception {
 
-    final SubscriptionOffsetCheckpointer checkpointer1 = new SubscriptionOffsetCheckpointer(client, true);
+    final SubscriptionOffsetCheckpointer checkpointer1 = new SubscriptionOffsetCheckpointer(client)
+        .suppressInvalidSessionException(true);
     SubscriptionOffsetObserver observer = new SubscriptionOffsetObserver(checkpointer1);
     observer = spy(observer);
 


### PR DESCRIPTION
The constructor option was replaced with a fluent setter. This
removes the constructor in advance of 0.9.0.