### PR TITLE
0.9.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,18 @@
 ### Changes
 
+
+### 0.9.0
+
+Contains breaking changes relative to 0.8.x.
+
+- Breaking change. Removes deprecated means to suppress invalid exceptions.
+- Breaking change. Prevents stream processor start being called after stop.
+- Allow X-Flow-ID header to be specified by application. [#193](https://github.com/zalando-incubator/nakadi-java/issues/193)
+- Fixes stream processor shut down.  [#186](https://github.com/zalando-incubator/nakadi-java/issues/186)
+- Observer onError is only called when the consumer pipeline is going to stop processing.
+- Updates Observer documentation to reflect consumer retry policy.
+- Breaking change. Defaults stream processor to retry exceptions except for Errors and NonRetryableNakadiException.
+
 ### 0.8.8
 
 - Checks if the next pagination url is relative. [#204](https://github.com/zalando-incubator/nakadi-java/issues/204)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 - Build: [![CircleCI](https://circleci.com/gh/zalando-incubator/nakadi-java.svg?style=svg)](https://circleci.com/gh/zalando-incubator/nakadi-java)
 - Release Download: [ ![Download](https://api.bintray.com/packages/dehora/maven/nakadi-java-client/images/download.svg) ](https://bintray.com/dehora/maven/nakadi-java-client/_latestVersion)
-- Source Release: [0.8.8](https://github.com/zalando-incubator/nakadi-java/releases/tag/0.8.8)
+- Source Release: [0.9.0](https://github.com/zalando-incubator/nakadi-java/releases/tag/0.9.0)
 - Contact: [maintainers](https://github.com/zalando-incubator/nakadi-java/blob/master/MAINTAINERS)
 
 
@@ -101,7 +101,7 @@ The client's had some basic testing to verify it can handle things like
 consumer stream connection/network failures and retries. It should not be 
 deemed robust yet, but it is a goal to produce a well-behaved production 
 level client especially for producing and consuming events for 1.0.0. The 
-releases from 0.8.8 and onwards seem fairly sane.
+releases from 0.9.0 and onwards seem fairly sane.
 
 See also:
 
@@ -671,7 +671,7 @@ and add the project declaration to `pom.xml`:
 <dependency>
   <groupId>net.dehora.nakadi</groupId>
   <artifactId>nakadi-java-client</artifactId>
-  <version>0.8.8</version>
+  <version>0.9.0</version>
 </dependency>
 ```
 ### Gradle
@@ -688,7 +688,7 @@ and add the project to the `dependencies` block in `build.gradle`:
 
 ```groovy
 dependencies {
-  compile 'net.dehora.nakadi:nakadi-java-client:0.8.8'
+  compile 'net.dehora.nakadi:nakadi-java-client:0.9.0'
 }  
 ```
 
@@ -703,7 +703,7 @@ resolvers += "jcenter" at "http://jcenter.bintray.com"
 and add the project to `libraryDependencies` in `build.sbt`:
 
 ```scala
-libraryDependencies += "net.dehora.nakadi" % "nakadi-java-client" % "0.8.8"
+libraryDependencies += "net.dehora.nakadi" % "nakadi-java-client" % "0.9.0"
 ```
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # suppress inspection "UnusedProperty" for whole file
 org.gradle.daemon=true
-version=0.8.8
+version=0.9.0
 group=net.dehora.nakadi
 # one per line to keep diffs clean
 modules=\

--- a/nakadi-java-client/src/main/java/nakadi/Version.java
+++ b/nakadi-java-client/src/main/java/nakadi/Version.java
@@ -2,5 +2,5 @@ package nakadi;
 
 public class Version {
 
-  public static final String VERSION = "0.8.8";
+  public static final String VERSION = "0.9.0";
 }


### PR DESCRIPTION
Contains breaking changes relative to 0.8.x.

- Breaking change. Removes deprecated means to suppress invalid exceptions.
- Breaking change. Prevents stream processor start being called after stop.
- Allow X-Flow-ID header to be specified by application. [#193](https://github.com/zalando-incubator/nakadi-java/issues/193)
- Fixes stream processor shut down.  [#186](https://github.com/zalando-incubator/nakadi-java/issues/186)
- Observer onError is only called when the consumer pipeline is going to stop processing.
- Updates Observer documentation to reflect consumer retry policy.
- Breaking change. Defaults stream processor to retry exceptions except for Errors and NonRetryableNakadiException.
